### PR TITLE
Fix stale native task fallback registration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,10 @@ function debug(...args: unknown[]) {
   if (DEBUG) console.error("[pi-loop]", ...args);
 }
 
+function isStaleExtensionContextError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("extension ctx is stale");
+}
+
 export default function (pi: ExtensionAPI) {
   const piLoopEnv = process.env.PI_LOOP;
   const piLoopScope = process.env.PI_LOOP_SCOPE as "memory" | "session" | "project" | undefined;
@@ -297,30 +301,42 @@ export default function (pi: ExtensionAPI) {
 
   // ── Native task tools (only when pi-tasks is absent) ──
 
-  setTimeout(async () => {
+  const nativeTaskFallbackTimer = setTimeout(() => {
     if (tasksAvailable || nativeTasksRegistered) return;
-    nativeTaskStore = new TaskStore(resolveTaskStorePath(getScopeOptions(), _sessionId));
+    const taskStore = new TaskStore(resolveTaskStorePath(getScopeOptions(), _sessionId));
+
+    try {
+      registerTasksCommand({
+        pi,
+        getNativeTaskStore: () => nativeTaskStore,
+        evaluateTaskBacklog,
+        updateWidget: () => {
+          widget.update();
+        },
+      });
+
+      registerNativeTaskTools({
+        pi,
+        taskStore,
+        evaluateTaskBacklog,
+        updateWidget: () => {
+          widget.update();
+        },
+      });
+    } catch (error) {
+      if (isStaleExtensionContextError(error)) {
+        debug("native task fallback skipped: extension context went stale");
+        return;
+      }
+      throw error;
+    }
+
+    nativeTaskStore = taskStore;
     nativeTasksRegistered = true;
-    const taskStore = nativeTaskStore;
-
-    registerTasksCommand({
-      pi,
-      getNativeTaskStore: () => nativeTaskStore,
-      evaluateTaskBacklog,
-      updateWidget: () => {
-        widget.update();
-      },
-    });
-
-    registerNativeTaskTools({
-      pi,
-      taskStore,
-      evaluateTaskBacklog,
-      updateWidget: () => {
-        widget.update();
-      },
-    });
-
     debug("native task tools registered (pi-tasks not detected)");
   }, 6000);
+
+  pi.on("session_shutdown", () => {
+    clearTimeout(nativeTaskFallbackTimer);
+  });
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -71,6 +71,34 @@ describe("native task fallback", () => {
     expect(commandMap.has("tasks")).toBe(false);
   });
 
+  it("ignores delayed native fallback registration after the extension context goes stale", async () => {
+    const { pi } = createMockPi();
+    const staleError = new Error("This extension ctx is stale after session replacement or reload.");
+
+    extension(pi as any);
+    pi.registerCommand = vi.fn(() => {
+      throw staleError;
+    });
+    pi.registerTool = vi.fn(() => {
+      throw staleError;
+    });
+
+    await vi.advanceTimersByTimeAsync(6100);
+
+    expect(pi.registerCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels delayed native fallback registration on session shutdown", async () => {
+    const { pi, toolMap, commandMap, emitExtension } = createMockPi();
+
+    extension(pi as any);
+    await emitExtension("session_shutdown", null, {});
+    await vi.advanceTimersByTimeAsync(6100);
+
+    expect(toolMap.has("TaskCreate")).toBe(false);
+    expect(commandMap.has("tasks")).toBe(false);
+  });
+
   it("stores native tasks in a dedicated .pi/tasks/tasks.json path", async () => {
     const { pi, toolMap, extensionHandlers } = createMockPi();
 


### PR DESCRIPTION
## Issue / Task

Fixes the crash reported when the delayed native task fallback timer fired after a session replacement/reload:

```txt
pi exiting due to uncaughtException:
Error: This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().
    at Object.assertActive (.../pi-coding-agent/dist/core/extensions/loader.js:105:19)
    at Object.registerCommand (.../pi-coding-agent/dist/core/extensions/loader.js:166:21)
    at registerTasksCommand (.../@trevonistrevon/pi-loop/src/commands/tasks-command.ts:114:6)
    at Timeout._onTimeout (.../@trevonistrevon/pi-loop/src/index.ts:306:44)
    at listOnTimeout (node:internal/timers:608:17)
    at process.processTimers (node:internal/timers:543:7)
```

## Summary

Fixes a `pi-loop` crash caused by delayed native task fallback registration firing after a session replacement or reload. The old extension context can become stale, but the 6-second fallback timer still attempted to call `pi.registerCommand`, which pi rejects.

This PR cancels the fallback timer during `session_shutdown`, ignores stale-context registration errors if the timer still races, and only marks native task fallback as registered after registration succeeds.

## What happened

```mermaid
flowchart TD
  A[pi-loop extension starts] --> B[Check if pi-tasks is available]
  B --> C[Start 6s native task fallback timer]
  C --> D{Session replaced / reloads before timer fires?}

  D -- Yes --> E[Old extension pi context becomes stale]
  E --> F[Old timer fires]
  F --> G[Attempts pi.registerCommand for /tasks]
  G --> H[Crash: extension ctx is stale]

  D -- No --> I[Fallback registers normally]

  H --> J[Fix in this PR]
  J --> K[Clear fallback timer on session_shutdown]
  J --> L[Ignore stale-context errors if race still happens]
  J --> M[Set nativeTasksRegistered only after successful registration]
```

## Test Plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`
- [x] Added regression test for stale delayed fallback registration
- [x] Added regression test for shutdown canceling fallback registration
