### PR TITLE
fix(store): tolerate directory-fsync EPERM on Windows (loops/workflows/monitors/tasks can't persist)

### DIFF
--- a/src/reducer-backed-store.ts
+++ b/src/reducer-backed-store.ts
@@ -131,7 +131,16 @@ export abstract class ReducerBackedStore<TEntry extends { id: string }, TState, 
     if (!this.filePath) return;
     const fd = openSync(dirname(this.filePath), "r");
     try {
-      fsyncSync(fd);
+      // Directory fsync is best-effort dirent durability (POSIX only). Windows'
+      // FlushFileBuffers needs write access on the handle and throws EPERM on a
+      // read-only directory descriptor, and the file fsync in writeSnapshot()
+      // already made the bytes durable.
+      try {
+        fsyncSync(fd);
+      } catch (error) {
+        if (process.platform === "win32" && (error as NodeJS.ErrnoException).code === "EPERM") return;
+        throw error;
+      }
     } finally {
       closeSync(fd);
     }

--- a/test/reducer-backed-store.dir-fsync.test.ts
+++ b/test/reducer-backed-store.dir-fsync.test.ts
@@ -1,0 +1,91 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AnyReducerEffect } from "../src/coordinator.js";
+
+// Regression: on Windows, fsync() (FlushFileBuffers) on a read-only directory
+// handle throws EPERM. writeSnapshot() fsyncs twice per write — the temp file
+// (writable handle, succeeds) then the parent directory (read-only "r" handle,
+// EPERM on Windows). Simulate that by throwing on every second fsyncSync call.
+const counter = vi.hoisted(() => ({ n: 0, directoryErrorCode: "EPERM" }));
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		fsyncSync: () => {
+			counter.n += 1;
+			if (counter.n % 2 === 0) {
+				throw Object.assign(
+					new Error(`simulated Windows directory fsync ${counter.directoryErrorCode}`),
+					{ code: counter.directoryErrorCode },
+				);
+			}
+			// odd calls (the file fsync) succeed
+		},
+	};
+});
+
+// Import the module UNDER TEST after the mock is registered so its named import
+// of fsyncSync resolves to the mock above.
+const { ReducerBackedStore } = await import("../src/reducer-backed-store.js");
+
+interface Thing {
+	id: string;
+}
+const config = {
+	baseDir: join(tmpdir(), "pi-loop-dir-fsync"),
+	reduce: (_s: { nextId: number }, _e: never) => ({ state: _s, effects: [] as AnyReducerEffect[] }),
+	toReducerState: (nextId: number, _entries: Map<string, Thing>) => ({ nextId }),
+	fromReducerState: (state: { nextId: number }) => ({ nextId: state.nextId, entries: new Map<string, Thing>() }),
+	serialize: (nextId: number, entries: Map<string, Thing>) => ({ nextId, items: Array.from(entries.keys()) }),
+	deserialize: (data: { nextId: number; items: string[] }) => ({
+		nextId: data.nextId,
+		entries: new Map(data.items.map((id) => [id, { id }] as const)),
+	}),
+};
+
+class ThingStore extends ReducerBackedStore<Thing, { nextId: number }, never, { nextId: number; items: string[] }> {
+	constructor(path?: string) {
+		// @ts-expect-error -- minimal config shape satisfies the base constructor at runtime
+		super(config, path);
+	}
+	write(): void {
+		this.withLock(() => {
+			(this.entries as Map<string, Thing>).set(`t${this.nextId}`, { id: `t${this.nextId}` });
+			this.nextId += 1;
+		});
+	}
+}
+
+describe("ReducerBackedStore directory fsync (Windows EPERM)", () => {
+	let dir: string;
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "pi-loop-dirfsync-"));
+		counter.n = 0;
+		counter.directoryErrorCode = "EPERM";
+		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+		vi.restoreAllMocks();
+	});
+
+	it("survives a directory-fsync EPERM and still persists the snapshot", () => {
+		const path = join(dir, "things.json");
+		const store = new ThingStore(path);
+
+		// Before the fix this threw EPERM out of syncDirectory() on Windows.
+		expect(() => store.write()).not.toThrow();
+		expect(existsSync(path)).toBe(true);
+		const onDisk = JSON.parse(readFileSync(path, "utf-8"));
+		expect(onDisk.items).toEqual(["t1"]);
+	});
+
+	it("surfaces directory-fsync errors other than Windows EPERM", () => {
+		counter.directoryErrorCode = "EIO";
+		const store = new ThingStore(join(dir, "things.json"));
+
+		expect(() => store.write()).toThrow(/simulated Windows directory fsync EIO/);
+	});
+});


### PR DESCRIPTION
## Problem

On Windows, the entire pi-loop persistence layer throws `EPERM: operation not permitted, fsync` on every state write — so **loops, workflows, monitors, and tasks cannot persist** on Windows hosts. `MonitorCreate` / `LoopCreate` / `WorkflowCreate` / task mutations all fail.

## Root cause

`ReducerBackedStore.syncDirectory()` does a POSIX-style directory fsync for dirent durability:

```ts
const fd = openSync(dirname(this.filePath), "r");
try {
  fsyncSync(fd);   // ← EPERM on Windows
} finally {
  closeSync(fd);
}
```

On Windows, `fsync()` maps to `FlushFileBuffers`, which **requires write access on the handle**. A directory opened read-only (`"r"`) has no write access, so it throws `EPERM`. This runs on every snapshot write (`writeSnapshot()` → `syncDirectory()`), so `LoopStore` and `TaskStore` (both `extends ReducerBackedStore`) are fully broken on Windows.

This is the same class of bug as [oh-my-openagent#3837](https://github.com/code-yeongyu/oh-my-openagent/issues/3837). It doesn't reproduce on macOS/Linux CI because POSIX allows fsync on a read-only directory descriptor — which is why it slipped through.

## Fix

Wrap the directory fsync in `try/catch`. Directory fsync is **best-effort** dirent durability (POSIX-only); `writeSnapshot()`'s file fsync on the temp file (writable handle) already made the bytes durable, so dropping the dir-fsync failure is safe. No behavior change on POSIX.

```ts
try {
  fsyncSync(fd);
} catch {
  // best-effort on platforms without writable directory fsync (e.g. Windows)
}
```

## Verification

- `npm run typecheck`, `npm run build`, `biome check` — clean.
- New cross-platform regression test `test/reducer-backed-store.dir-fsync.test.ts` simulates the Windows failure (mocks `fsyncSync` to throw on the 2nd call per write — file fsync ok, dir fsync EPERM, matching `writeSnapshot()`'s call order) and asserts the snapshot still persists. **It fails on `master` and passes with this fix** (verified by stashing).
- On this Windows host, the monitor suite goes from **9 failing → 4 failing** with this change (the 5 fixed were the dir-fsync victims). The remaining 4 are a *separate* Windows issue (temp-dir cleanup `EPERM` on `rmSync`), out of scope here.

## Scope

This is the minimal fix for the directory-fsync EPERM only. The remaining Windows temp-dir cleanup failures are tracked separately.
