### PR TITLE
feat(workflow): add per-state cron policies

### DIFF
--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -95,6 +95,8 @@ WorkflowTransition id="1" outcome="tests_pass" evidence="Targeted and full test 
 
 `WorkflowTransition` validates the branch, settles the current state task, records evidence, creates the next state's optional task, and queues the next wake. Pass `claimId` when the current state task was claimed; do not complete or close a linked state task with `TaskUpdate`. A self-loop creates a fresh linked attempt and increments the displayed attempt count. A task settlement failure leaves the workflow in its source state. When a target reaches `maxAttempts`, only outcomes leading to that target become unavailable; other declared outcomes remain selectable. Reaching a `completed` terminal state deletes the workflow loop; reaching a `paused` terminal state preserves it in paused state for inspection or deletion. Terminal workflow states cannot be resumed. Task status does not guess an outcome—the model selects one explicitly. LoopList and workflow wakes omit outcomes whose target state has exhausted `maxAttempts`.
 
+To repeat a state until evidence supports an outcome, add a cron-only state policy: `"loop":{"schedule":"0 7 * * *","maxFires":10,"startImmediately":false}`. Only the active state's policy is armed. Scheduled wakes retain the linked state task; `WorkflowTransition` remains the only operation that settles it and unlocks the destination task and cadence. `maxFires` is local to that state and pauses the workflow when exhausted. State policies do not wake immediately unless `startImmediately` is `true`.
+
 `LoopList` includes workflow state, active task, transition evidence, and valid outcomes alongside ordinary loops.
 
 ### Inspecting and stopping loops

--- a/docs/WORKFLOW_HARNESS_TESTING.md
+++ b/docs/WORKFLOW_HARNESS_TESTING.md
@@ -13,6 +13,8 @@ A workflow state task represents one state attempt.
 - A legacy state task that is already terminal may be reconciled by an explicit `WorkflowTransition`; task status never selects the outcome.
 - Terminal workflow completion removes the controller only after its final linked task is settled.
 
+When a state has a cron loop policy, repeated scheduled fires belong to the same state attempt: the linked task remains active, and only `WorkflowTransition` settles it. Tests must verify that only the active state policy is armed, its local fire count persists, and its local fire cap pauses the controller.
+
 The wake message and `LoopList` summary expose `Attempt: current/max`, the active task ID, allowed outcomes, and the rule that linked tasks must not be terminally updated through `TaskUpdate`.
 
 ## Deterministic tests

--- a/docs/architecture/durable-runtime-recovery.md
+++ b/docs/architecture/durable-runtime-recovery.md
@@ -26,6 +26,8 @@ Session death and process death are different. A closed session can leave a live
 | Monitors | Memory-only `ChildProcess` map | Handles, output, result, timeout, and `onDone` delivery are lost. Descendants may outlive the shell. |
 | Deletion tombstones | Loop-store memory/snapshot lifecycle | Not sufficient to cancel a message already accepted by Pi. |
 
+Workflow snapshots include state-local loop fire counts. On recovery, the scheduler re-arms only the current nonterminal state's cron policy, retaining its linked task and local cap; inactive-state policies never fire until `WorkflowTransition` enters their state.
+
 ## Audit findings
 
 ### 1. Fire and delivery are not one recoverable operation

--- a/docs/architecture/workflow-contract.md
+++ b/docs/architecture/workflow-contract.md
@@ -12,15 +12,16 @@ Workflow loops are a controller layer over dynamic loops and tasks. They are not
 
 ## Definition
 
-`WorkflowDefinition` version 1 contains an `initialState` and named states. A state has a prompt, optional `task`, outcome map `on`, optional positive `maxAttempts`, or a terminal status of `completed` or `paused`.
+`WorkflowDefinition` version 1 contains an `initialState` and named states. A state has a prompt, optional `task`, outcome map `on`, optional positive `maxAttempts`, optional cron-only `loop` policy (`schedule`, optional positive `maxFires`, optional `startImmediately`), or a terminal status of `completed` or `paused`.
 
-Every declared outcome must target a named state. Terminal states may not declare outcomes. A state may be entered at most `maxAttempts` times when that limit is set.
+Every declared outcome must target a named state. Terminal states may not declare outcomes or loop policies. A state may be entered at most `maxAttempts` times when that limit is set. Only the active state's loop policy is armed; a scheduled wake retains the active linked task until an explicit transition. A state-local `maxFires` pauses the workflow controller when exhausted. `startImmediately` opts into an initial idle wake; otherwise the first wake follows the cron schedule.
 
 ## Run invariants
 
 - `currentState` always names a definition state.
 - `transitionSeq` increases exactly once for every accepted transition.
 - `attemptsByState` increases when a state is entered.
+- `stateFireCounts` records delivered scheduled wakes by state and survives state transitions and recovery.
 - `lastTransition` records source, destination, outcome, evidence, timestamp, and sequence.
 - `activeTaskId`, when present, belongs to the current state transition sequence and remains nonterminal until `WorkflowTransition` settles that attempt.
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -44,6 +44,7 @@ export type {
   WorkflowDefinition,
   WorkflowRunState,
   WorkflowStateDefinition,
+  WorkflowStateLoopDefinition,
   WorkflowTaskDefinition,
   WorkflowTerminalStatus,
   WorkflowTransitionRecord,

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import { registerWorkflowTools } from "./tools/workflow-tools.js";
 import { TriggerSystem } from "./trigger-system.js";
 import type { LoopEntry, Trigger } from "./types.js";
 import { LoopWidget } from "./ui/widget.js";
+import { atWorkflowStateFireLimit, getActiveWorkflowStateLoop } from "./workflow-reducer.js";
 
 const DEBUG = !!process.env.PI_LOOP_DEBUG;
 function debug(...args: unknown[]) {
@@ -191,7 +192,8 @@ export default function (pi: ExtensionAPI) {
     store.fire(entry.id);
 
     const firedAt = Date.now();
-    const firedEntry = entry.trigger.type === "dynamic"
+    const stateLoop = entry.workflow && getActiveWorkflowStateLoop(entry.workflow);
+    const firedEntry = entry.trigger.type === "dynamic" && !stateLoop
       ? store.updateDynamic(entry.id, {
           dynamic: {
             awaitingUpdate: true,
@@ -200,6 +202,12 @@ export default function (pi: ExtensionAPI) {
           },
         }) ?? entry
       : entry;
+
+    if (firedEntry.workflow && atWorkflowStateFireLimit(firedEntry.workflow)) {
+      triggerSystem.remove(firedEntry.id);
+      store.pause(firedEntry.id);
+      widget.update();
+    }
 
     if (entry.autoTask) {
       taskProvider?.autoCreateTask(entry).then((taskId) => {

--- a/src/loop-reducer.ts
+++ b/src/loop-reducer.ts
@@ -196,6 +196,16 @@ export function reduceLoopState(state: LoopReducerState, event: LoopReducerEvent
 
   if (event.type === "LOOP_FIRED") {
     loop.fireCount = (loop.fireCount ?? 0) + 1;
+    if (loop.workflow) {
+      const stateId = loop.workflow.currentState;
+      loop.workflow = {
+        ...loop.workflow,
+        stateFireCounts: {
+          ...(loop.workflow.stateFireCounts ?? {}),
+          [stateId]: (loop.workflow.stateFireCounts?.[stateId] ?? 0) + 1,
+        },
+      };
+    }
     loop.updatedAt = event.at;
   }
 

--- a/src/runtime/notification-runtime.ts
+++ b/src/runtime/notification-runtime.ts
@@ -137,6 +137,10 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
         lines.push(...formatLastTransitionLines(data.workflow.lastTransition));
       }
       if (state?.prompt) lines.push(`State instructions: ${state.prompt}`);
+      if (state?.loop) {
+        const fires = data.workflow.stateFireCounts?.[data.workflow.currentState] ?? 0;
+        lines.push(`State cadence: ${state.loop.schedule} · fires: ${fires}/${state.loop.maxFires ?? "unbounded"}`);
+      }
       if (data.workflow.activeTaskId) {
         lines.push(
           `Active task: #${data.workflow.activeTaskId}`,
@@ -149,6 +153,11 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
       }
       if (state?.terminal) {
         lines.push(`Terminal: ${state.terminal} — this workflow state is terminal; no transition is needed.`);
+      } else if (state?.loop) {
+        lines.push(
+          `Workflow lifecycle: Loop #${loopId} runs this state on its configured cadence until an acceptance condition is met.`,
+          "Continue the linked task and preserve its claim. Do not call WorkflowTransition merely because this iteration finished; call it only with a declared outcome and supporting evidence when the state can advance.",
+        );
       } else {
         lines.push(
           `Workflow lifecycle: Loop #${loopId} is an opt-in state controller. Do not call LoopDelete after this state.`,

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,8 +1,11 @@
 import { computeJitter, cronToNextFire } from "./loop-parse.js";
 import type { LoopStore } from "./store.js";
 import type { LoopEntry } from "./types.js";
+import { atWorkflowStateFireLimit, getActiveWorkflowStateLoop } from "./workflow-reducer.js";
 
 function computeNextFire(entry: LoopEntry): Date {
+  const workflowLoop = entry.workflow && getActiveWorkflowStateLoop(entry.workflow);
+  if (workflowLoop) return cronToNextFire(workflowLoop.schedule);
   if (entry.trigger.type === "cron" || entry.trigger.type === "hybrid") {
     return cronToNextFire(entry.trigger.type === "hybrid" ? entry.trigger.cron : entry.trigger.schedule);
   }
@@ -66,8 +69,10 @@ export class CronScheduler {
   private armTimer(entry: LoopEntry): void {
     const nextFire = computeNextFire(entry);
     let jitter = 0;
-    if (entry.trigger.type === "cron" || entry.trigger.type === "hybrid") {
-      const scheduleExpr = entry.trigger.type === "hybrid" ? entry.trigger.cron : entry.trigger.schedule;
+    const workflowLoop = entry.workflow && getActiveWorkflowStateLoop(entry.workflow);
+    if (workflowLoop || entry.trigger.type === "cron" || entry.trigger.type === "hybrid") {
+      const scheduleExpr = workflowLoop?.schedule
+        ?? (entry.trigger.type === "hybrid" ? entry.trigger.cron : entry.trigger.type === "cron" ? entry.trigger.schedule : "");
       const minuteField = scheduleExpr.trim().split(/\s+/)[0] ?? "";
       const minuteStep = minuteField.startsWith("*/") ? parseInt(minuteField.slice(2), 10) || 30 : 30;
       jitter = computeJitter(entry.id, entry.recurring, minuteStep);
@@ -87,12 +92,12 @@ export class CronScheduler {
       if (now < fireTime) continue;
 
       const entry = this.store.get(id);
-      if (!entry || entry.status !== "active") {
+      if (entry?.status !== "active") {
         this.fireTimes.delete(id);
         continue;
       }
 
-      if (entry.trigger.type === "dynamic" && entry.dynamic?.awaitingUpdate) continue;
+      if (entry.trigger.type === "dynamic" && entry.dynamic?.awaitingUpdate && !entry.workflow) continue;
 
       if (filter && !filter(entry)) continue;
 
@@ -115,6 +120,11 @@ export class CronScheduler {
       }
 
       if (fresh.maxFires && (fresh.fireCount ?? 0) >= fresh.maxFires) {
+        this.retire(fresh);
+        continue;
+      }
+
+      if (fresh.workflow && atWorkflowStateFireLimit(fresh.workflow)) {
         this.retire(fresh);
         continue;
       }

--- a/src/tools/loop-tools.ts
+++ b/src/tools/loop-tools.ts
@@ -4,6 +4,7 @@ import { formatTrigger } from "../loop-format.js";
 import { parseInterval } from "../loop-parse.js";
 import type { LoopEntry, Trigger } from "../types.js";
 import { renderToolCall, renderToolResult, toolArg } from "../ui/tool-renderer.js";
+import { getActiveWorkflowStateLoop } from "../workflow-reducer.js";
 import { displayRows, textResult } from "./tool-result.js";
 import { formatWorkflowSummary } from "./workflow-tools.js";
 
@@ -388,9 +389,12 @@ Use this before creating new loops to avoid duplicates, or to find IDs for LoopD
 
       const lines: string[] = [];
       for (const entry of loops) {
-        const triggerDesc = formatTrigger(entry.trigger, "list");
+        const workflowSchedule = entry.workflow && getActiveWorkflowStateLoop(entry.workflow)?.schedule;
+        const triggerDesc = workflowSchedule ? `workflow cron: ${workflowSchedule}` : formatTrigger(entry.trigger, "list");
 
-        const nextFire = entry.trigger.type === "cron" || entry.trigger.type === "hybrid" || entry.dynamic?.nextWakeAt !== undefined ? getScheduler().nextFire(entry.id) : undefined;
+        const nextFire = workflowSchedule || entry.trigger.type === "cron" || entry.trigger.type === "hybrid" || entry.dynamic?.nextWakeAt !== undefined
+          ? getScheduler().nextFire(entry.id)
+          : undefined;
         const statusIcon = entry.status === "active" ? "*" : entry.status === "paused" ? "-" : "x";
         let line = `${statusIcon} #${entry.id} [${entry.status}] ${entry.prompt.slice(0, 60)}`;
         line += ` (${triggerDesc})`;

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -3,7 +3,7 @@ import { Type } from "typebox";
 import { formatLastTransitionLines } from "../loop-format.js";
 import type { LoopEntry, Trigger, WorkflowDefinition } from "../types.js";
 import { renderToolCall, renderToolResult, toolArg } from "../ui/tool-renderer.js";
-import { getWorkflowOutcomeAvailability, transitionWorkflowRun, validateWorkflowDefinition, type WorkflowTransitionFailure } from "../workflow-reducer.js";
+import { getActiveWorkflowStateLoop, getWorkflowOutcomeAvailability, transitionWorkflowRun, validateWorkflowDefinition, type WorkflowTransitionFailure } from "../workflow-reducer.js";
 import { textResult } from "./tool-result.js";
 
 interface WorkflowStoreLike {
@@ -66,7 +66,17 @@ function parseWorkflowDefinition(input: string): { definition?: WorkflowDefiniti
 }
 
 const WORKFLOW_DEFINITION_EXAMPLE =
-  '{"version":1,"initialState":"investigate","states":{"investigate":{"prompt":"Investigate the issue.","on":{"found":"done"}},"done":{"prompt":"Report completion.","terminal":"completed"}}}';
+  '{"version":1,"initialState":"collect","states":{"collect":{"prompt":"Collect evidence.","loop":{"schedule":"0 7 * * *","maxFires":10},"on":{"ready":"publish"}},"publish":{"prompt":"Publish the result.","terminal":"completed"}}}';
+
+function workflowDefaultMaxFires(definition: WorkflowDefinition): number {
+  const loopBudget = Object.values(definition.states)
+    .reduce((total, state) => total + (state.loop?.maxFires ?? 0), 0);
+  return loopBudget > 0 ? loopBudget : 30;
+}
+
+function stateLoopStartsImmediately(entry: LoopEntry): boolean {
+  return Boolean(entry.workflow && getActiveWorkflowStateLoop(entry.workflow)?.startImmediately);
+}
 
 function formatWorkflowDefinitionError(error: string | undefined): string {
   return `Workflow definition rejected: ${error ?? "unknown validation error"}\n` +
@@ -91,6 +101,10 @@ export function formatWorkflowSummary(entry: LoopEntry, heading: string, failure
   let message = `${heading}\nGoal: ${entry.prompt}\nCurrent state: ${workflow.currentState}\nAttempt: ${attemptLabel}`;
   if (workflow.lastTransition) message += `\n${formatLastTransitionLines(workflow.lastTransition).join("\n")}`;
   if (state?.prompt) message += `\nInstruction: ${state.prompt}`;
+  if (state?.loop) {
+    const fires = workflow.stateFireCounts?.[workflow.currentState] ?? 0;
+    message += `\nState cadence: ${state.loop.schedule} · fires: ${fires}/${state.loop.maxFires ?? "unbounded"}`;
+  }
   if (workflow.activeTaskId) {
     message += `\nActive task: #${workflow.activeTaskId}`;
   } else if (state?.task) {
@@ -129,11 +143,12 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
     label: "WorkflowCreate",
     renderCall: renderToolCall("Workflow", (args) => `create · ${String(toolArg(args, "goal") ?? "workflow").slice(0, 56)}`),
     renderResult: renderToolResult,
-    description: `Create a task-driven workflow for named phases and outcomes. The JSON definition needs version 1, a nonterminal initialState, and states with prompt, optional task: {subject, description}, outcome map, maxAttempts, or terminal status.`,
+    description: "Create a task-driven workflow for named phases and outcomes. Use task: {subject, description} for state work. A state can use a cron loop policy (`schedule`, `maxFires`, `startImmediately`); only the active state's policy runs.",
     promptGuidelines: [
       "Use WorkflowCreate for named phase/outcome flows, not flat backlogs.",
       "Give nonterminal states concise prompts and explicit outcomes.",
       "WorkflowTransition settles linked state tasks; never terminally TaskUpdate them.",
+      "A state loop repeats while that state remains active; only WorkflowTransition unlocks the next state's task and cadence.",
       "Model rework as outcome cycles bounded by maxAttempts; re-entry increments attempts.",
       "On each wake call WorkflowTransition once with id, outcome, evidence, and active-task claimId.",
     ],
@@ -157,7 +172,7 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
 
       let entry = getStore().create({ type: "dynamic" }, params.goal, {
         recurring: true,
-        maxFires: params.maxFires ?? 30,
+        maxFires: params.maxFires ?? workflowDefaultMaxFires(parsed.definition),
         dynamic: { goal: params.goal, state: parsed.definition.initialState, iteration: 0 },
         workflow: parsed.definition,
       });
@@ -183,9 +198,15 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
       }
       getTriggerSystem().add(entry);
       updateWidget();
-      onDynamicLoopActivated?.(entry);
+      if (!entry.workflow || !getActiveWorkflowStateLoop(entry.workflow) || stateLoopStartsImmediately(entry)) {
+        onDynamicLoopActivated?.(entry);
+      }
       return textResult(
-        `${formatWorkflowSummary(entry, `Workflow #${entry.id} created — ${entry.status}`)}\nWake: the state instruction will be delivered when the agent becomes idle.`,
+        `${formatWorkflowSummary(entry, `Workflow #${entry.id} created — ${entry.status}`)}\nWake: ${
+          entry.workflow && getActiveWorkflowStateLoop(entry.workflow)
+            ? stateLoopStartsImmediately(entry) ? "initial state wake queued now; subsequent wakes follow the state cadence." : "scheduled from the active state cadence."
+            : "the state instruction will be delivered when the agent becomes idle."
+        }`,
         {
           kind: "workflow",
           action: "create",
@@ -195,7 +216,9 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
             `Goal: ${entry.prompt}`,
             `State: ${parsed.definition.initialState}`,
             `Outcome: ${Object.keys(parsed.definition.states[parsed.definition.initialState]?.on ?? {}).join(", ") || "none"}`,
-            "Wake: delivered when the agent becomes idle",
+            entry.workflow && getActiveWorkflowStateLoop(entry.workflow)
+              ? `Cadence: ${getActiveWorkflowStateLoop(entry.workflow)?.schedule}`
+              : "Wake: delivered when the agent becomes idle",
           ],
         },
       );
@@ -315,6 +338,7 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
       const taskId = existingTaskId ?? createdTaskId;
       getTriggerSystem().add(updatedEntry);
       updateWidget();
+      if (stateLoopStartsImmediately(updatedEntry)) onDynamicLoopActivated?.(updatedEntry);
       const from = updatedEntry.workflow?.lastTransition?.from ?? "?";
       const to = updatedEntry.workflow?.currentState ?? "?";
       return textResult(

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,9 +54,16 @@ export interface WorkflowTaskDefinition {
   description: string;
 }
 
+export interface WorkflowStateLoopDefinition {
+  schedule: string;
+  maxFires?: number;
+  startImmediately?: boolean;
+}
+
 export interface WorkflowStateDefinition {
   prompt: string;
   task?: WorkflowTaskDefinition;
+  loop?: WorkflowStateLoopDefinition;
   on?: Record<string, string>;
   terminal?: WorkflowTerminalStatus;
   maxAttempts?: number;
@@ -83,6 +90,7 @@ export interface WorkflowRunState {
   transitionSeq: number;
   stateEnteredAt: number;
   attemptsByState: Record<string, number>;
+  stateFireCounts: Record<string, number>;
   activeTaskId?: string;
   lastTransition?: WorkflowTransitionRecord;
 }

--- a/src/workflow-reducer.ts
+++ b/src/workflow-reducer.ts
@@ -1,6 +1,8 @@
+import { isValidCronExpression } from "./loop-parse.js";
 import type {
   WorkflowDefinition,
   WorkflowRunState,
+  WorkflowStateLoopDefinition,
   WorkflowTerminalStatus,
   WorkflowTransitionRecord,
 } from "./types.js";
@@ -9,6 +11,7 @@ export type {
   WorkflowDefinition,
   WorkflowRunState,
   WorkflowStateDefinition,
+  WorkflowStateLoopDefinition,
   WorkflowTerminalStatus,
   WorkflowTransitionRecord,
 } from "./types.js";
@@ -35,6 +38,15 @@ export interface WorkflowOutcomeAvailability {
   unavailable: Array<{ outcome: string; targetState: string; maxAttempts: number }>;
 }
 
+export function getActiveWorkflowStateLoop(run: WorkflowRunState): WorkflowStateLoopDefinition | undefined {
+  return run.definition.states[run.currentState]?.loop;
+}
+
+export function atWorkflowStateFireLimit(run: WorkflowRunState): boolean {
+  const loop = getActiveWorkflowStateLoop(run);
+  return loop?.maxFires !== undefined && (run.stateFireCounts?.[run.currentState] ?? 0) >= loop.maxFires;
+}
+
 export function getWorkflowOutcomeAvailability(run: WorkflowRunState): WorkflowOutcomeAvailability {
   const state = run.definition.states[run.currentState];
   const available: string[] = [];
@@ -50,7 +62,7 @@ export function getWorkflowOutcomeAvailability(run: WorkflowRunState): WorkflowO
 }
 
 export function validateWorkflowDefinition(definition: WorkflowDefinition): string | undefined {
-  if (!definition || definition.version !== 1) return "Workflow version must be 1";
+  if (definition?.version !== 1) return "Workflow version must be 1";
   if (!definition.states || typeof definition.states !== "object") return "Workflow states must be an object";
   if (!definition.initialState || !definition.states[definition.initialState]) {
     return `Initial state "${definition.initialState}" is not defined`;
@@ -73,6 +85,15 @@ export function validateWorkflowDefinition(definition: WorkflowDefinition): stri
     if (state.maxAttempts !== undefined && (!Number.isInteger(state.maxAttempts) || state.maxAttempts < 1)) {
       return `State "${stateId}" maxAttempts must be a positive integer`;
     }
+    if (state.loop) {
+      if (!isValidCronExpression(state.loop.schedule)) {
+        return `State "${stateId}" loop schedule must be a valid 5-field cron expression`;
+      }
+      if (state.loop.maxFires !== undefined && (!Number.isInteger(state.loop.maxFires) || state.loop.maxFires < 1)) {
+        return `State "${stateId}" loop maxFires must be a positive integer`;
+      }
+      if (state.terminal) return `Terminal state "${stateId}" cannot declare a loop policy`;
+    }
     for (const [outcome, target] of Object.entries(state.on ?? {})) {
       if (!outcome) return `State "${stateId}" has an empty outcome name`;
       if (typeof target !== "string") return `Transition "${stateId}.${outcome}" target must be a state ID`;
@@ -90,6 +111,7 @@ export function createWorkflowRun(definition: WorkflowDefinition, at: number): W
     transitionSeq: 0,
     stateEnteredAt: at,
     attemptsByState: { [definition.initialState]: 1 },
+    stateFireCounts: {},
   };
 }
 
@@ -141,6 +163,7 @@ export function transitionWorkflowRun(
     transitionSeq: sequence,
     stateEnteredAt: at,
     attemptsByState: { ...run.attemptsByState, [target]: nextAttempt },
+    stateFireCounts: run.stateFireCounts ?? {},
     activeTaskId: input.activeTaskId,
     lastTransition,
   };

--- a/test/loop-tools.test.ts
+++ b/test/loop-tools.test.ts
@@ -401,10 +401,54 @@ describe("Workflow tools", () => {
       trigger: { type: "dynamic" },
       workflow: { currentState: "investigate", transitionSeq: 0 },
     });
+
     expect(h.triggerSystem.add).toHaveBeenCalledWith(h.store.get("1"));
     expect(h.onDynamicLoopActivated).toHaveBeenCalledWith(h.store.get("1"));
     expect(h.toolMap.get("WorkflowCreate")?.renderCall).toBeTypeOf("function");
     expect(h.toolMap.get("WorkflowTransition")?.renderResult).toBeTypeOf("function");
+  });
+
+  it("creates a scheduled workflow state without an immediate wake", async () => {
+    const scheduledDefinition = JSON.stringify({
+      version: 1,
+      initialState: "collect",
+      states: {
+        collect: {
+          prompt: "Collect records.",
+          task: { subject: "Collect records", description: "Gather the required input." },
+          loop: { schedule: "0 7 * * *", maxFires: 4 },
+          on: { ready: "publish" },
+        },
+        publish: { prompt: "Publish records.", terminal: "completed" },
+      },
+    });
+
+    const out = await h.text("WorkflowCreate", { goal: "Process records", definition: scheduledDefinition });
+
+    expect(out).toContain("State cadence: 0 7 * * * · fires: 0/4");
+    expect(out).toContain("scheduled from the active state cadence");
+    expect(h.onDynamicLoopActivated).not.toHaveBeenCalled();
+    expect(h.triggerSystem.add).toHaveBeenCalledWith(h.store.get("1"));
+  });
+
+  it("immediately wakes a scheduled workflow state that requests it", async () => {
+    const scheduledDefinition = JSON.stringify({
+      version: 1,
+      initialState: "collect",
+      states: {
+        collect: {
+          prompt: "Collect records.",
+          loop: { schedule: "0 7 * * *", startImmediately: true },
+          on: { ready: "publish" },
+        },
+        publish: { prompt: "Publish records.", terminal: "completed" },
+      },
+    });
+
+    const out = await h.text("WorkflowCreate", { goal: "Process records", definition: scheduledDefinition });
+
+    expect(out).toContain("initial state wake queued now");
+    expect(h.onDynamicLoopActivated).toHaveBeenCalledWith(h.store.get("1"));
   });
 
   it("rejects creation when its initial task cannot bind to the original state", async () => {
@@ -712,7 +756,7 @@ describe("Workflow tools", () => {
 
     expect(out).toContain("Workflow definition rejected: Workflow version must be 1");
     expect(out).toContain("Required fields: version: 1, initialState, and states.");
-    expect(out).toContain('"initialState":"investigate"');
+    expect(out).toContain('"initialState":"collect"');
     expect(out).toContain("Next: correct the JSON and call WorkflowCreate again.");
   });
 

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -107,10 +107,73 @@ describe("CronScheduler", () => {
       recurring: true,
       dynamic: { goal: "finish goal", iteration: 0 },
     });
+
     scheduler.add(entry);
 
     scheduler.pump(Date.now());
     expect(fired).toContain("1");
+  });
+
+  it("arms only the active workflow state's cron policy", () => {
+    scheduler = new CronScheduler(store, (entry) => {
+      fired.push(entry.id);
+      store.fire(entry.id);
+    });
+    const entry = store.create({ type: "dynamic" }, "Process records", {
+      recurring: true,
+      workflow: {
+        version: 1,
+        initialState: "collect",
+        states: {
+          collect: { prompt: "Collect records.", loop: { schedule: "0 7 * * *" }, on: { ready: "publish" } },
+          publish: { prompt: "Publish records.", loop: { schedule: "*/1 * * * *" }, on: { done: "complete" } },
+          complete: { prompt: "Finished.", terminal: "completed" },
+        },
+      },
+      dynamic: { goal: "Process records", iteration: 0 },
+    });
+    scheduler.add(entry);
+
+    vi.advanceTimersByTime(60 * 1000);
+    scheduler.pump(Date.now());
+    expect(fired).toHaveLength(0);
+
+    const transitioned = store.transitionWorkflow(entry.id, { outcome: "ready" });
+    if (!transitioned.entry) throw new Error("expected workflow transition");
+    scheduler.remove(entry.id);
+    scheduler.add(transitioned.entry);
+
+    vi.advanceTimersByTime(2 * 60 * 1000);
+    scheduler.pump(Date.now());
+    expect(fired).toEqual([entry.id]);
+    expect(store.get(entry.id)?.workflow?.stateFireCounts).toEqual({ publish: 1 });
+  });
+
+  it("pauses a workflow when its active state reaches its local fire cap", () => {
+    scheduler = new CronScheduler(store, (entry) => {
+      fired.push(entry.id);
+      store.fire(entry.id);
+    });
+    const entry = store.create({ type: "dynamic" }, "Process records", {
+      recurring: true,
+      workflow: {
+        version: 1,
+        initialState: "collect",
+        states: {
+          collect: { prompt: "Collect records.", loop: { schedule: "*/1 * * * *", maxFires: 1 }, on: { ready: "complete" } },
+          complete: { prompt: "Finished.", terminal: "completed" },
+        },
+      },
+      dynamic: { goal: "Process records", iteration: 0 },
+    });
+    scheduler.add(entry);
+
+    vi.advanceTimersByTime(2 * 60 * 1000);
+    scheduler.pump(Date.now());
+
+    expect(fired).toEqual([entry.id]);
+    expect(store.get(entry.id)?.status).toBe("paused");
+    expect(store.get(entry.id)?.workflow?.stateFireCounts).toEqual({ collect: 1 });
   });
 
   it("does not refire idle-driven dynamic loops while awaiting update", () => {

--- a/test/workflow-reducer.test.ts
+++ b/test/workflow-reducer.test.ts
@@ -32,6 +32,7 @@ describe("workflow reducer", () => {
       transitionSeq: 0,
       stateEnteredAt: 100,
       attemptsByState: { investigate: 1 },
+      stateFireCounts: {},
     });
   });
 
@@ -123,5 +124,36 @@ describe("workflow reducer", () => {
         investigate: { ...definition.states.investigate, on: { continue: "missing" } },
       },
     })).toBe('Transition "investigate.continue" targets unknown state "missing"');
+  });
+
+  it("validates optional cron loop policies only on nonterminal states", () => {
+    const scheduled: WorkflowDefinition = {
+      version: 1,
+      initialState: "collect",
+      states: {
+        collect: {
+          prompt: "Collect input.",
+          loop: { schedule: "0 7 * * *", maxFires: 4 },
+          on: { ready: "done" },
+        },
+        done: { prompt: "Publish output.", terminal: "completed" },
+      },
+    };
+
+    expect(validateWorkflowDefinition(scheduled)).toBeUndefined();
+    expect(validateWorkflowDefinition({
+      ...scheduled,
+      states: {
+        ...scheduled.states,
+        collect: { ...scheduled.states.collect, loop: { schedule: "not cron" } },
+      },
+    })).toBe('State "collect" loop schedule must be a valid 5-field cron expression');
+    expect(validateWorkflowDefinition({
+      ...scheduled,
+      states: {
+        ...scheduled.states,
+        done: { ...scheduled.states.done, loop: { schedule: "0 7 * * *" } },
+      },
+    })).toBe('Terminal state "done" cannot declare a loop policy');
   });
 });


### PR DESCRIPTION
## What

Adds per-state cron policies to the workflow engine.

- Run only the active state cadence with local fire caps
- Preserve linked tasks until explicit state transitions
- Persist state fire counts across recovery

## Why

Workflow states previously shared a single global fire cadence. Each state now carries its own cron policy so the active state drives the next wake, and fire counts survive recovery instead of resetting.

## Test plan

- `npm run test:coverage` — 630 tests pass
- `npm run lint` — clean (5 pre-existing warnings unrelated to this change)