### PR TITLE
chore(deps): update patch dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@vitest/coverage-v8": "^4.1.8",
         "fast-check": "^4.9.0",
         "tsx": "^4.23.1",
-        "typebox": "1.3.8",
+        "typebox": "1.3.11",
         "typescript": "^7.0.2",
         "vitest": "^4.1.5"
       },
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.6.tgz",
-      "integrity": "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.7.tgz",
+      "integrity": "sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -106,20 +106,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.6",
-        "@biomejs/cli-darwin-x64": "2.5.6",
-        "@biomejs/cli-linux-arm64": "2.5.6",
-        "@biomejs/cli-linux-arm64-musl": "2.5.6",
-        "@biomejs/cli-linux-x64": "2.5.6",
-        "@biomejs/cli-linux-x64-musl": "2.5.6",
-        "@biomejs/cli-win32-arm64": "2.5.6",
-        "@biomejs/cli-win32-x64": "2.5.6"
+        "@biomejs/cli-darwin-arm64": "2.5.7",
+        "@biomejs/cli-darwin-x64": "2.5.7",
+        "@biomejs/cli-linux-arm64": "2.5.7",
+        "@biomejs/cli-linux-arm64-musl": "2.5.7",
+        "@biomejs/cli-linux-x64": "2.5.7",
+        "@biomejs/cli-linux-x64-musl": "2.5.7",
+        "@biomejs/cli-win32-arm64": "2.5.7",
+        "@biomejs/cli-win32-x64": "2.5.7"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.6.tgz",
-      "integrity": "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.7.tgz",
+      "integrity": "sha512-vxo/Ls3/PYdQWyLhYYcgMOCzQypAjcY+iihS8M0wW03l16TCLW4zqZzGo75gm1VdCMj38hTVZ31KBWrZ4G9dJw==",
       "cpu": [
         "arm64"
       ],
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.6.tgz",
-      "integrity": "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.7.tgz",
+      "integrity": "sha512-Cd3Ga61amT/Yl/0x8elP5hhGYaFy4bw6WuysTgf7oo8TA5tJ5A1k+DkVoJ2BHbTVil51gTX9VPzArnrlLJ3Kyg==",
       "cpu": [
         "x64"
       ],
@@ -151,9 +151,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.6.tgz",
-      "integrity": "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.7.tgz",
+      "integrity": "sha512-rR2QE0yF2GYSuYuKIa7pKvODGJqnOH+2eDREAM8wV+mWKSkMQKdAp4zXEZfTaxY8PMoNONnpgSWcBCyLDPDOKg==",
       "cpu": [
         "arm64"
       ],
@@ -171,9 +171,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.6.tgz",
-      "integrity": "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.7.tgz",
+      "integrity": "sha512-xPI5yB6XlpDbNkS+bm1t42olw5c4l3UrlOmLg7KtLJvjvkNF/1V4tnUgfkylGIeb3u/T+BzMGYqgQhzjAoJzuQ==",
       "cpu": [
         "arm64"
       ],
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.6.tgz",
-      "integrity": "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.7.tgz",
+      "integrity": "sha512-FQgqJhscrqJUFptGaRSUJWlXAExwWcDwLuK49dvKfkQ1bB5SEEyFssnsxQY83Xm6jR0EbbX3+8+D5bfvYqUG2Q==",
       "cpu": [
         "x64"
       ],
@@ -211,9 +211,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.6.tgz",
-      "integrity": "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.7.tgz",
+      "integrity": "sha512-rE5VZi+qtmPgQH+l7jVxYoZ18b/TiHEhulhMpjmCZH1PltSbjRcxNWywC3HZ9tYottG7ORkeTtoscBilKSBm0g==",
       "cpu": [
         "x64"
       ],
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.6.tgz",
-      "integrity": "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.7.tgz",
+      "integrity": "sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg==",
       "cpu": [
         "arm64"
       ],
@@ -248,9 +248,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.6.tgz",
-      "integrity": "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.7.tgz",
+      "integrity": "sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ==",
       "cpu": [
         "x64"
       ],
@@ -4366,9 +4366,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
-      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "version": "4.23.9",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.9.tgz",
+      "integrity": "sha512-6q8uTORRGauQVjqMQnKUucLFoeXZAfw6zKvG35GLbdKWbLdeOtZ3H4mhyA5mxuUd2o2cRTskhj59nLLQseUvUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4385,9 +4385,9 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.8.tgz",
-      "integrity": "sha512-xYaJgF0KMvBViKWRaKTAtfR6sDt/yH6xAjGAHXYJxKxUF4pVyPXZZhIlwOg6cDIE81N7L0pyIHs136RHBm6rLQ==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.11.tgz",
+      "integrity": "sha512-tZGKIS02Opbh4EYMmAEVuXl+y3EQJ9ZlkitLZ1CmFCY4ZOqr/xWR9dDSCFmIjNDICGMWkOqMh6WxGTyRXqcSGQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@vitest/coverage-v8": "^4.1.8",
     "fast-check": "^4.9.0",
     "tsx": "^4.23.1",
-    "typebox": "1.3.8",
+    "typebox": "1.3.11",
     "typescript": "^7.0.2",
     "vitest": "^4.1.5"
   },


### PR DESCRIPTION
Replaces Dependabot #27, #28, and #29 with one signed maintainer commit required by the repository ruleset.

Updates:
- `tsx` 4.23.1 → 4.23.9
- `typebox` 1.3.8 → 1.3.11
- `@biomejs/biome` lockfile 2.5.6 → 2.5.7

Validation:
- `npm ci`
- `npm run typecheck`
- `npm run lint`
- `npm run audit:all`
- `npm test` (648 tests)
- `npm run build`
- `npm run test:package`

Closes #27
Closes #28
Closes #29
