### PR TITLE
fix(monitor): clean up terminal resources

### DIFF
--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -132,7 +132,9 @@ For a monitor launched from an active workflow, use `workflowId` instead of `onD
 MonitorCreate command="npm test" description="Validate release" workflowId="29"
 ```
 
-The workflow pauses its cadence while the monitor runs. On success, failure, timeout, or stop, it resumes the same state once with status, stop reason, exit code, and output count; inspect the result and call `WorkflowTransition` with a declared outcome. Do not poll with `LoopUpdate` while it waits.
+The workflow pauses its cadence while the monitor runs. While the same Pi runtime remains active, success, failure, timeout, or explicit `MonitorStop` resumes the same state once with status, stop reason, exit code, and output count; inspect the result and call `WorkflowTransition` with a declared outcome. Do not poll with `LoopUpdate` while it waits.
+
+A session shutdown or switch interrupts the monitor: its in-memory process and wait are discarded without a terminal workflow wake. In session or project scope, inspect the resumed workflow and start a new monitor if the work still needs to run; memory-scoped workflows are discarded.
 
 ```text
 MonitorList

--- a/src/monitor-manager.ts
+++ b/src/monitor-manager.ts
@@ -98,6 +98,28 @@ export class MonitorManager {
     bp.terminalCallbacks = [];
   }
 
+  private clearDeadline(bp: MonitorProcess): void {
+    if (!bp.deadlineTimer) return;
+    clearTimeout(bp.deadlineTimer);
+    bp.deadlineTimer = undefined;
+  }
+
+  private signalProcessTree(bp: MonitorProcess, signal: NodeJS.Signals): void {
+    if (process.platform === "win32") {
+      try {
+        nodeSpawn("taskkill", ["/pid", String(bp.pid), "/t", "/f"], { stdio: "ignore", windowsHide: true })
+          .on("error", () => { try { bp.proc.kill(signal); } catch { /* already dead */ } });
+        return;
+      } catch { /* fall through to the direct child */ }
+    } else {
+      try {
+        process.kill(-bp.pid, signal);
+        return;
+      } catch { /* fall through to the direct child */ }
+    }
+    try { bp.proc.kill(signal); } catch { /* already dead */ }
+  }
+
   // Retain terminal state long enough for a completion wake to inspect it.
   private schedulePrune(id: string): void {
     if (this.shuttingDown) return;
@@ -138,6 +160,7 @@ export class MonitorManager {
       stdio: ["ignore", "pipe", "pipe"],
       signal: abortController.signal,
       env: { ...process.env },
+      detached: process.platform !== "win32",
     });
 
     const bp: MonitorProcess = {
@@ -163,6 +186,7 @@ export class MonitorManager {
 
     const finish = (code: number | null, status: "completed" | "error") => {
       if (this.shuttingDown) return;
+      this.clearDeadline(bp);
       this.flushOutput(id, bp);
       this.emitOutputProgress(id, bp);
       this.applyReducerEvent({
@@ -206,6 +230,7 @@ export class MonitorManager {
 
     child.on("error", (err) => {
       if (!this.shuttingDown && bp.entry.status === "running") {
+        this.clearDeadline(bp);
         this.flushOutput(id, bp);
         this.emitOutputProgress(id, bp);
         this.applyReducerEvent({
@@ -235,15 +260,18 @@ export class MonitorManager {
         this.notifyTerminal(bp, current);
         for (const resolve of bp.waiters) resolve();
         bp.waiters = [];
+        this.schedulePrune(id);
       }
     });
 
     if (timeout > 0) {
-      setTimeout(() => {
+      const deadlineTimer = setTimeout(() => {
         if (!this.shuttingDown && bp.entry.status === "running") {
           void this.stop(id, "timeout");
         }
       }, timeout);
+      deadlineTimer.unref?.();
+      bp.deadlineTimer = deadlineTimer;
     }
 
     this.processes.set(id, bp);
@@ -273,6 +301,7 @@ export class MonitorManager {
 
     this.shuttingDown = true;
     const processes = Array.from(this.processes.values());
+    for (const bp of processes) this.clearDeadline(bp);
     const running = processes.filter((bp) => bp.entry.status === "running");
     const shutdown = Promise.allSettled(running.map((bp) => this.stop(bp.entry.id)))
       .then(() => {
@@ -295,6 +324,7 @@ export class MonitorManager {
     const bp = this.processes.get(id);
     if (!bp || bp.entry.status !== "running") return false;
 
+    this.clearDeadline(bp);
     this.emitOutputProgress(id, bp);
     this.applyReducerEvent({
       type: "MONITOR_STOPPED",
@@ -314,7 +344,7 @@ export class MonitorManager {
       outputLines: bp.entry.outputLines,
     });
     if (!this.shuttingDown) this.schedulePrune(id);
-    bp.proc.kill("SIGTERM");
+    this.signalProcessTree(bp, "SIGTERM");
 
     if (reason === "timeout") {
       this.emit("monitor:error", {
@@ -329,7 +359,7 @@ export class MonitorManager {
 
     await new Promise<void>((resolve) => {
       const timer = setTimeout(() => {
-        try { bp.proc.kill("SIGKILL"); } catch { /* already dead */ }
+        this.signalProcessTree(bp, "SIGKILL");
         resolve();
       }, 5000);
 

--- a/src/monitor-manager.ts
+++ b/src/monitor-manager.ts
@@ -12,6 +12,11 @@ import type { MonitorEntry, MonitorProcess, MonitorProgress } from "./types.js";
 
 export type SpawnFn = (command: string, args: string[], options: SpawnOptions) => ChildProcess;
 
+export interface MonitorManagerOptions {
+  platform?: NodeJS.Platform;
+  taskkillSpawn?: SpawnFn;
+}
+
 const OUTPUT_EVENT_INTERVAL_MS = 1000;
 const MAX_OUTPUT_LINE_LENGTH = 4096;
 const OUTPUT_RATE_WINDOW_MS = 60000;
@@ -22,14 +27,19 @@ export class MonitorManager {
   private nextId = 1;
   private onChange: (() => void) | undefined;
   private spawnFn: SpawnFn;
+  private platform: NodeJS.Platform;
+  private taskkillSpawn: SpawnFn;
   private shutdownPromise: Promise<void> | undefined;
   private shuttingDown = false;
 
   constructor(
     private pi: ExtensionAPI,
     spawnFn?: SpawnFn,
+    options: MonitorManagerOptions = {},
   ) {
     this.spawnFn = spawnFn ?? ((cmd, args, opts) => nodeSpawn(cmd, args, opts));
+    this.platform = options.platform ?? process.platform;
+    this.taskkillSpawn = options.taskkillSpawn ?? ((cmd, args, opts) => nodeSpawn(cmd, args, opts));
   }
 
   /**
@@ -105,19 +115,36 @@ export class MonitorManager {
   }
 
   private signalProcessTree(bp: MonitorProcess, signal: NodeJS.Signals): void {
-    if (process.platform === "win32") {
+    let fellBack = false;
+    const fallback = () => {
+      if (fellBack) return;
+      fellBack = true;
+      try { bp.proc.kill(signal); } catch { /* already dead */ }
+    };
+
+    if (this.platform === "win32") {
       try {
-        nodeSpawn("taskkill", ["/pid", String(bp.pid), "/t", "/f"], { stdio: "ignore", windowsHide: true })
-          .on("error", () => { try { bp.proc.kill(signal); } catch { /* already dead */ } });
+        const taskkill = this.taskkillSpawn(
+          "taskkill",
+          ["/pid", String(bp.pid), "/t", "/f"],
+          { stdio: "ignore", windowsHide: true },
+        );
+        taskkill.once("error", fallback);
+        taskkill.once("close", (code) => {
+          if (code !== 0) fallback();
+        });
         return;
-      } catch { /* fall through to the direct child */ }
-    } else {
-      try {
-        process.kill(-bp.pid, signal);
+      } catch {
+        fallback();
         return;
-      } catch { /* fall through to the direct child */ }
+      }
     }
-    try { bp.proc.kill(signal); } catch { /* already dead */ }
+
+    try {
+      process.kill(-bp.pid, signal);
+    } catch {
+      fallback();
+    }
   }
 
   // Retain terminal state long enough for a completion wake to inspect it.
@@ -160,7 +187,7 @@ export class MonitorManager {
       stdio: ["ignore", "pipe", "pipe"],
       signal: abortController.signal,
       env: { ...process.env },
-      detached: process.platform !== "win32",
+      detached: this.platform !== "win32",
     });
 
     const bp: MonitorProcess = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,6 +164,7 @@ export interface MonitorProcess {
   pid: number;
   proc: import("node:child_process").ChildProcess;
   abortController: AbortController;
+  deadlineTimer?: ReturnType<typeof setTimeout>;
   waiters: Array<() => void>;
   completionCallbacks: Array<(monitor: MonitorEntry) => void>;
   terminalCallbacks: Array<(monitor: MonitorEntry) => void>;

--- a/test/monitor-manager.test.ts
+++ b/test/monitor-manager.test.ts
@@ -9,18 +9,24 @@ import { createMockChildProcess, createSequentialSpawn } from "./helpers/mock-sp
 describe("MonitorManager", () => {
   let manager: MonitorManager;
   let pi: any;
+  let mockPi: ReturnType<typeof createMockPi>;
 
   beforeEach(() => {
-    pi = createMockPi().pi;
+    mockPi = createMockPi();
+    pi = mockPi.pi;
     manager = new MonitorManager(pi);
   });
 
   function startBackgroundChild(timeout: number) {
     const dir = mkdtempSync(join(tmpdir(), "pi-loop-tree-"));
     const marker = join(dir, "survived");
+    let unsubscribe: (() => void) | undefined;
     const ready = new Promise<void>((resolve) => {
-      pi.events.on("monitor:output", (event: { line?: string }) => {
-        if (event.line === "tree-ready") resolve();
+      unsubscribe = pi.events.on("monitor:output", (event: { line?: string }) => {
+        if (event.line !== "tree-ready") return;
+        unsubscribe?.();
+        unsubscribe = undefined;
+        resolve();
       });
     });
     const entry = manager.create(
@@ -28,7 +34,16 @@ describe("MonitorManager", () => {
       "process-tree cleanup",
       timeout,
     );
-    return { entry, marker, ready, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+    return {
+      entry,
+      marker,
+      ready,
+      cleanup: () => {
+        unsubscribe?.();
+        unsubscribe = undefined;
+        rmSync(dir, { recursive: true, force: true });
+      },
+    };
   }
 
   afterEach(async () => {
@@ -707,6 +722,41 @@ describe("MonitorManager", () => {
     expect(stopped).toBe(true);
     expect(manager.get(entry.id)!.status).toBe("stopped");
     vi.useRealTimers();
+  });
+
+  it("removes the helper output listener during cleanup", async () => {
+    const child = startBackgroundChild(0);
+
+    try {
+      expect(mockPi.eventHandlers.get("monitor:output")).toHaveLength(1);
+      child.cleanup();
+      expect(mockPi.eventHandlers.get("monitor:output")).toHaveLength(0);
+    } finally {
+      await manager.stop(child.entry.id);
+    }
+  });
+
+  it("falls back when taskkill exits nonzero", async () => {
+    const child = createMockChildProcess({ exitCode: null });
+    const taskkill = createMockChildProcess({ exitCode: null });
+    const taskkillSpawn = vi.fn(() => taskkill);
+    manager = new MonitorManager(pi, createSequentialSpawn(child), {
+      platform: "win32",
+      taskkillSpawn,
+    });
+    const entry = manager.create("sleep 30", "taskkill fallback", 0);
+    const stop = manager.stop(entry.id);
+
+    taskkill.emit("close", 1);
+    expect((child as { killed: boolean }).killed).toBe(true);
+    expect(taskkillSpawn).toHaveBeenCalledWith(
+      "taskkill",
+      ["/pid", expect.any(String), "/t", "/f"],
+      { stdio: "ignore", windowsHide: true },
+    );
+
+    child.emit("close", 0);
+    await stop;
   });
 
   it("releases the default deadline timer after normal completion", () => {

--- a/test/monitor-manager.test.ts
+++ b/test/monitor-manager.test.ts
@@ -1,3 +1,6 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MONITOR_RETENTION_MS, MonitorManager } from "../src/monitor-manager.js";
 import { createMockPi } from "./helpers/mock-pi.js";
@@ -11,6 +14,22 @@ describe("MonitorManager", () => {
     pi = createMockPi().pi;
     manager = new MonitorManager(pi);
   });
+
+  function startBackgroundChild(timeout: number) {
+    const dir = mkdtempSync(join(tmpdir(), "pi-loop-tree-"));
+    const marker = join(dir, "survived");
+    const ready = new Promise<void>((resolve) => {
+      pi.events.on("monitor:output", (event: { line?: string }) => {
+        if (event.line === "tree-ready") resolve();
+      });
+    });
+    const entry = manager.create(
+      `sh -c 'sleep 0.15; touch ${JSON.stringify(marker)}' & printf 'tree-ready\\n'; wait`,
+      "process-tree cleanup",
+      timeout,
+    );
+    return { entry, marker, ready, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+  }
 
   afterEach(async () => {
     for (const m of manager.list()) {
@@ -688,5 +707,136 @@ describe("MonitorManager", () => {
     expect(stopped).toBe(true);
     expect(manager.get(entry.id)!.status).toBe("stopped");
     vi.useRealTimers();
+  });
+
+  it("releases the default deadline timer after normal completion", () => {
+    const child = createMockChildProcess({ exitCode: null });
+    const deadlineTimer = { unref: vi.fn() };
+    const retentionTimer = { unref: vi.fn() };
+    const realSetTimeout = global.setTimeout;
+    const timeoutSpy = vi.spyOn(global, "setTimeout").mockImplementation(((fn: TimerHandler, ms?: number, ...args: any[]) => {
+      if (ms === 300000) return deadlineTimer as any;
+      if (ms === MONITOR_RETENTION_MS) return retentionTimer as any;
+      return realSetTimeout(fn, ms, ...args);
+    }) as typeof setTimeout);
+    const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+    manager = new MonitorManager(pi, createSequentialSpawn(child));
+
+    manager.create("echo done", "deadline cleanup");
+    child.emit("close", 0);
+
+    expect(deadlineTimer.unref).toHaveBeenCalledOnce();
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(deadlineTimer);
+    timeoutSpy.mockRestore();
+  });
+
+  it("releases the default deadline timer after manual stop", async () => {
+    const child = createMockChildProcess({ exitCode: 0 });
+    const deadlineTimer = { unref: vi.fn() };
+    const retentionTimer = { unref: vi.fn() };
+    const realSetTimeout = global.setTimeout;
+    const timeoutSpy = vi.spyOn(global, "setTimeout").mockImplementation(((fn: TimerHandler, ms?: number, ...args: any[]) => {
+      if (ms === 300000) return deadlineTimer as any;
+      if (ms === MONITOR_RETENTION_MS) return retentionTimer as any;
+      return realSetTimeout(fn, ms, ...args);
+    }) as typeof setTimeout);
+    const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+    manager = new MonitorManager(pi, createSequentialSpawn(child));
+    const entry = manager.create("sleep 30", "deadline cleanup");
+
+    await manager.stop(entry.id);
+
+    expect(deadlineTimer.unref).toHaveBeenCalledOnce();
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(deadlineTimer);
+    timeoutSpy.mockRestore();
+  });
+
+  it("releases the default deadline timer during shutdown", async () => {
+    const child = createMockChildProcess({ exitCode: 0 });
+    const deadlineTimer = { unref: vi.fn() };
+    const realSetTimeout = global.setTimeout;
+    const timeoutSpy = vi.spyOn(global, "setTimeout").mockImplementation(((fn: TimerHandler, ms?: number, ...args: any[]) => {
+      if (ms === 300000) return deadlineTimer as any;
+      return realSetTimeout(fn, ms, ...args);
+    }) as typeof setTimeout);
+    const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+    manager = new MonitorManager(pi, createSequentialSpawn(child));
+    manager.create("sleep 30", "shutdown deadline cleanup");
+
+    await manager.shutdown();
+
+    expect(deadlineTimer.unref).toHaveBeenCalledOnce();
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(deadlineTimer);
+    timeoutSpy.mockRestore();
+  });
+
+  it("retains then prunes a monitor whose child emits an error", () => {
+    const child = createMockChildProcess({ exitCode: null });
+    const retainedTimers: Array<() => void> = [];
+    const realSetTimeout = global.setTimeout;
+    const timeoutSpy = vi.spyOn(global, "setTimeout").mockImplementation(((fn: TimerHandler, ms?: number, ...args: any[]) => {
+      if (ms === MONITOR_RETENTION_MS) {
+        retainedTimers.push(() => {
+          if (typeof fn === "function") fn(...args);
+        });
+        return { unref: vi.fn() } as any;
+      }
+      if (ms === 300000) return { unref: vi.fn() } as any;
+      return realSetTimeout(fn, ms, ...args);
+    }) as typeof setTimeout);
+    manager = new MonitorManager(pi, createSequentialSpawn(child));
+    const entry = manager.create("missing-command", "spawn error");
+
+    child.emit("error", new Error("spawn failed"));
+
+    expect(manager.get(entry.id)?.status).toBe("error");
+    expect(retainedTimers).toHaveLength(1);
+    retainedTimers[0]!();
+    expect(manager.get(entry.id)).toBeUndefined();
+    timeoutSpy.mockRestore();
+  });
+
+  it.skipIf(process.platform === "win32")("stops the shell's background child process", async () => {
+    const child = startBackgroundChild(0);
+
+    try {
+      await child.ready;
+      await manager.stop(child.entry.id);
+      await new Promise<void>((resolve) => setTimeout(resolve, 250));
+      expect(existsSync(child.marker)).toBe(false);
+    } finally {
+      child.cleanup();
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("times out the shell's background child process", async () => {
+    const child = startBackgroundChild(25);
+    const stopped = new Promise<void>((resolve) => {
+      pi.events.on("monitor:finished", (event: { monitorId?: string; status?: string }) => {
+        if (event.monitorId === child.entry.id && event.status === "stopped") resolve();
+      });
+    });
+
+    try {
+      await child.ready;
+      await stopped;
+      await new Promise<void>((resolve) => setTimeout(resolve, 250));
+      expect(existsSync(child.marker)).toBe(false);
+    } finally {
+      child.cleanup();
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("shuts down the shell's background child process", async () => {
+    const child = startBackgroundChild(0);
+
+    try {
+      await child.ready;
+      await manager.shutdown();
+      await new Promise<void>((resolve) => setTimeout(resolve, 250));
+      expect(existsSync(child.marker)).toBe(false);
+    } finally {
+      child.cleanup();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Clear monitor deadlines and prune spawn errors.
- Stop monitor process trees.
- Clarify session-boundary behavior.

## Validation
- npm test
- npm run typecheck
- npm run build && npm run test:package