### PR TITLE
fix(runtime): harden workflow execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ MonitorStop monitorId="1"
 
 - Cron, event, hybrid, dynamic goal, and opt-in workflow loops
 - Idle-safe agent re-wakes with dynamic-loop restart/session-switch recovery
-- Background command monitoring with buffered output and `onDone` wakes
+- Background command monitoring with buffered output, `onDone` wakes, and timeout alerts
 - Optional `pi-tasks` integration and a native task fallback
 - Session-isolated persistence and a compact TUI status line
 

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -121,10 +121,10 @@ Output is buffered and emitted as `monitor:output`. A monitor finishes as one of
 
 - clean exit: emits `monitor:done`
 - nonzero exit or spawn failure: emits `monitor:error`
-- timeout: stops the process, emits `monitor:error`, and reports the timeout
+- timeout: stops the process, emits `monitor:error`, and always wakes the agent after the process reaps
 - explicit `MonitorStop`: cancels the monitor without an `onDone` wake; workflow-owned monitors resume their current state with `status=stopped`
 
-Pass `onDone` whenever the agent should resume work after completion. Its one-shot wake fires on success, failure, or timeout. The default timeout is five minutes; use `timeout=0` to disable it.
+Pass `onDone` whenever the agent should resume work after success or failure. Its one-shot wake also fires on timeout; monitors without `onDone` still send a timeout-only alert. The default timeout is five minutes; use `timeout=0` to disable it.
 
 For a monitor launched from an active workflow, use `workflowId` instead of `onDone`:
 

--- a/src/commands/tasks-command.ts
+++ b/src/commands/tasks-command.ts
@@ -1,12 +1,14 @@
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
-import { emitNativeTaskEvent } from "../runtime/task-events.js";
+import {
+  createTask,
+  deleteTask,
+  type TaskBacklogResult,
+  type TaskMutationContext,
+  taskMutationRejectionMessage,
+  updateTask,
+} from "../runtime/task-mutations.js";
 import { TaskStore } from "../task-store.js";
-import type { TaskEntry } from "../task-types.js";
 
-export interface TaskBacklogResult {
-  created: boolean;
-  entry?: { id: string };
-}
 
 export interface TasksCommandOptions {
   pi: ExtensionAPI;
@@ -18,13 +20,14 @@ export interface TasksCommandOptions {
 export function registerTasksCommand(options: TasksCommandOptions): void {
   const { pi, getNativeTaskStore, evaluateTaskBacklog, updateWidget } = options;
 
-  async function emitCreated(entry: TaskEntry) {
-    emitNativeTaskEvent(pi, "tasks:created", entry);
+  function mutationContext(taskStore: TaskStore): TaskMutationContext {
+    return { pi, taskStore, evaluateTaskBacklog, updateWidget };
+  }
+
+  async function createNativeTask(subject: string, description: string) {
     const taskStore = getNativeTaskStore();
-    if (!taskStore) return { created: false } satisfies TaskBacklogResult;
-    const backlog = await evaluateTaskBacklog(taskStore, taskStore.pendingCount());
-    updateWidget();
-    return backlog;
+    if (!taskStore) return undefined;
+    return await createTask(mutationContext(taskStore), { subject, description });
   }
 
   async function createNativeTaskInteractively(ui: ExtensionUIContext) {
@@ -37,11 +40,11 @@ export function registerTasksCommand(options: TasksCommandOptions): void {
     const subject = await ui.input("Task subject");
     if (!subject) return;
     const description = await ui.input("Task description") || subject;
-    const entry = taskStore.create(subject, description);
-    const backlog = await emitCreated(entry);
-    ui.notify(`Task #${entry.id} created`, "info");
-    if (backlog.created && backlog.entry) {
-      ui.notify(`Backlog worker loop #${backlog.entry.id} created`, "info");
+    const created = await createNativeTask(subject, description);
+    if (!created) return;
+    ui.notify(`Task #${created.entry.id} created`, "info");
+    if (created.backlog.created && created.backlog.entry) {
+      ui.notify(`Backlog worker loop #${created.backlog.entry.id} created`, "info");
     }
   }
 
@@ -96,29 +99,30 @@ export function registerTasksCommand(options: TasksCommandOptions): void {
     }
 
     let changed = false;
+    let rejection: string | undefined;
     if (action === "x Delete") {
-      changed = taskStore.delete(task.id, claimId);
-      if (changed) emitNativeTaskEvent(pi, "tasks:deleted", task, task.status);
-    } else if (action === "> Start") {
-      const next = taskStore.start(task.id);
-      changed = next !== undefined;
-      if (next) emitNativeTaskEvent(pi, "tasks:started", next, task.status);
-    } else if (action === "ok Complete") {
-      const next = taskStore.complete(task.id, claimId);
-      changed = next !== undefined;
-      if (next) emitNativeTaskEvent(pi, "tasks:completed", next, task.status);
-    } else if (action === "x Close without completing") {
-      const next = taskStore.close(task.id, claimId);
-      changed = next !== undefined;
-      if (next) emitNativeTaskEvent(pi, "tasks:closed", next, task.status);
-    } else if (action === "* Reopen") {
-      const next = taskStore.reopen(task.id);
-      changed = next !== undefined;
-      if (next) emitNativeTaskEvent(pi, "tasks:reopened", next, task.status);
+      const result = await deleteTask(mutationContext(taskStore), { id: task.id, claimId });
+      changed = result.applied;
+      if (!result.applied) rejection = taskMutationRejectionMessage(task.id, result);
+    } else {
+      const status = action === "> Start"
+        ? "in_progress"
+        : action === "ok Complete"
+          ? "completed"
+          : action === "x Close without completing"
+            ? "closed"
+            : action === "* Reopen"
+              ? "pending"
+              : undefined;
+      if (status) {
+        const result = await updateTask(mutationContext(taskStore), { id: task.id, status, claimId });
+        changed = result.applied;
+        if (!result.applied) rejection = taskMutationRejectionMessage(task.id, result);
+      }
     }
 
     if (!changed) {
-      ui.notify(`Task #${task.id} unchanged: operation rejected`, "warning");
+      ui.notify(`Task #${task.id} unchanged: ${rejection ?? "operation rejected"}`, "warning");
       return viewNativeTasks(ui);
     }
     const pastTense = action === "x Delete" ? "deleted"
@@ -127,8 +131,6 @@ export function registerTasksCommand(options: TasksCommandOptions): void {
           : action === "x Close without completing" ? "closed without completing"
             : "reopened";
     ui.notify(`Task #${task.id} ${pastTense}`, "info");
-    updateWidget();
-    await evaluateTaskBacklog(taskStore, taskStore.pendingCount());
     return viewNativeTasks(ui);
   }
 
@@ -142,11 +144,11 @@ export function registerTasksCommand(options: TasksCommandOptions): void {
         return;
       }
       if (trimmed) {
-        const entry = taskStore.create(trimmed.slice(0, 80), trimmed);
-        const backlog = await emitCreated(entry);
-        ctx.ui.notify(`Task #${entry.id} created`, "info");
-        if (backlog.created && backlog.entry) {
-          ctx.ui.notify(`Backlog worker loop #${backlog.entry.id} created`, "info");
+        const created = await createNativeTask(trimmed.slice(0, 80), trimmed);
+        if (!created) return;
+        ctx.ui.notify(`Task #${created.entry.id} created`, "info");
+        if (created.backlog.created && created.backlog.entry) {
+          ctx.ui.notify(`Backlog worker loop #${created.backlog.entry.id} created`, "info");
         }
         return;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,9 +163,11 @@ export default function (pi: ExtensionAPI) {
     resolveStorePath: () => resolveTaskStorePath(getScopeOptions(), _sessionId),
     getSessionId: () => _sessionId,
     evaluateTaskBacklog,
-    onReady: async () => {
-      await adoptTaskBacklogLoops();
+    onReady: async (detectionGeneration) => {
+      const generation = detectionGeneration ?? sessionGeneration;
+      await adoptTaskBacklogLoops(undefined, () => generation === sessionGeneration);
     },
+    getSessionGeneration: () => sessionGeneration,
     updateWidget: () => {
       widget.update();
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export default function (pi: ExtensionAPI) {
   const piLoopEnv = process.env.PI_LOOP;
   const piLoopScope = process.env.PI_LOOP_SCOPE as "memory" | "session" | "project" | undefined;
   let loopScope: "memory" | "session" | "project" = piLoopScope ?? "session";
+  let sessionGeneration = 0;
 
   const getScopeOptions = () => ({ piLoopEnv, loopScope });
 
@@ -188,6 +189,7 @@ export default function (pi: ExtensionAPI) {
       taskBacklog: entry.taskBacklog,
       dynamic: entry.dynamic,
       workflow: entry.workflow,
+      sessionGeneration,
       monitorOutcome: monitor
         ? {
             monitorId: monitor.id,
@@ -274,6 +276,8 @@ export default function (pi: ExtensionAPI) {
     pi,
     getLoopScope: () => loopScope,
     getPiLoopEnv: () => piLoopEnv,
+    getSessionGeneration: () => sessionGeneration,
+    advanceSessionGeneration: () => ++sessionGeneration,
     recreateSessionStore: (sessionId: string) => {
       const path = resolveLoopStorePath(getScopeOptions(), sessionId);
       if (path) store = new LoopStore(path);
@@ -332,6 +336,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.events.on("monitor:started", async (event: unknown) => {
+    const sourceGeneration = sessionGeneration;
     const data = event as {
       monitorId?: string;
       command?: string;
@@ -344,6 +349,7 @@ export default function (pi: ExtensionAPI) {
       command: data.command,
       description: data.description,
       timestamp: data.timestamp ?? Date.now(),
+      sessionGeneration: sourceGeneration,
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ import { registerLoopTools } from "./tools/loop-tools.js";
 import { registerMonitorTools } from "./tools/monitor-tools.js";
 import { registerWorkflowTools } from "./tools/workflow-tools.js";
 import { TriggerSystem } from "./trigger-system.js";
-import type { LoopEntry, MonitorEntry, Trigger } from "./types.js";
+import type { LoopEntry, LoopFireOrigin, MonitorEntry, Trigger } from "./types.js";
 import { LoopWidget } from "./ui/widget.js";
 import { atWorkflowStateFireLimit, getActiveWorkflowStateLoop, isTerminalWorkflowRun } from "./workflow-reducer.js";
 
@@ -64,8 +64,8 @@ export default function (pi: ExtensionAPI) {
   // call), so stale monitors don't linger in the count between turns.
   monitorManager.setOnChange(() => widget.update());
 
-  scheduler = new CronScheduler(store, onLoopFire);
-  triggerSystem = new TriggerSystem(pi, scheduler, store, onLoopFire);
+  scheduler = new CronScheduler(store, (entry, origin) => onLoopFire(entry, undefined, origin));
+  triggerSystem = new TriggerSystem(pi, scheduler, store, (entry, origin) => onLoopFire(entry, undefined, origin));
 
   let taskProvider: TaskProviderRuntime | undefined;
   const activeTaskBacklogWakes = new Set<string>();
@@ -202,7 +202,11 @@ export default function (pi: ExtensionAPI) {
     });
   }
 
-  function onLoopFire(entry: LoopEntry, monitor?: MonitorEntry): void {
+  function onLoopFire(
+    entry: LoopEntry,
+    monitor?: MonitorEntry,
+    origin: LoopFireOrigin = monitor ? "monitor" : "dynamic",
+  ): void {
     debug(`loop:fire #${entry.id}`, { prompt: entry.prompt.slice(0, 50) });
     const current = store.get(entry.id);
     if (current?.status !== "active" || isTerminalWorkflowRun(current?.workflow)) {
@@ -229,7 +233,7 @@ export default function (pi: ExtensionAPI) {
       return;
     }
     if (isTaskBacklog) activeTaskBacklogWakes.add(current.id);
-    const fired = store.fire(current.id);
+    const fired = store.fire(current.id, origin);
     if (!fired) return;
 
     const firedAt = Date.now();
@@ -286,8 +290,8 @@ export default function (pi: ExtensionAPI) {
         memoryLoopStores.set(sessionId, store);
       }
       widget.setStore(store);
-      scheduler = new CronScheduler(store, onLoopFire);
-      triggerSystem = new TriggerSystem(pi, scheduler, store, onLoopFire);
+      scheduler = new CronScheduler(store, (entry, origin) => onLoopFire(entry, undefined, origin));
+      triggerSystem = new TriggerSystem(pi, scheduler, store, (entry, origin) => onLoopFire(entry, undefined, origin));
     },
     clearAllLoops: () => {
       store.clearAll({ preserveWorkflows: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ import { registerWorkflowTools } from "./tools/workflow-tools.js";
 import { TriggerSystem } from "./trigger-system.js";
 import type { LoopEntry, MonitorEntry, Trigger } from "./types.js";
 import { LoopWidget } from "./ui/widget.js";
-import { atWorkflowStateFireLimit, getActiveWorkflowStateLoop } from "./workflow-reducer.js";
+import { atWorkflowStateFireLimit, getActiveWorkflowStateLoop, isTerminalWorkflowRun } from "./workflow-reducer.js";
 
 const DEBUG = !!process.env.PI_LOOP_DEBUG;
 function debug(...args: unknown[]) {
@@ -202,27 +202,33 @@ export default function (pi: ExtensionAPI) {
 
   function onLoopFire(entry: LoopEntry, monitor?: MonitorEntry): void {
     debug(`loop:fire #${entry.id}`, { prompt: entry.prompt.slice(0, 50) });
-    if (store.get(entry.id)?.workflow?.waitingMonitor) {
+    const current = store.get(entry.id);
+    if (current?.status !== "active" || isTerminalWorkflowRun(current?.workflow)) {
+      triggerSystem.remove(entry.id);
+      return;
+    }
+    if (current.workflow?.waitingMonitor) {
       debug(`workflow #${entry.id} — waiting on monitor; suppressing cadence wake`);
       return;
     }
 
-    const isTaskBacklog = taskBacklogRuntime.isTaskBacklogLoop(entry);
+    const isTaskBacklog = taskBacklogRuntime.isTaskBacklogLoop(current);
     if (isTaskBacklog && activeTaskBacklogWakes.has(entry.id)) {
       debug(`task backlog loop #${entry.id} — wake already active, adopting event into current wake`);
       return;
     }
 
-    if (atMaxFires(entry)) {
-      debug(`loop #${entry.id} — reached maxFires ${entry.maxFires}, retiring`);
-      triggerSystem.remove(entry.id);
-      if (entry.workflow || entry.taskBacklog) store.pause(entry.id);
-      else store.delete(entry.id);
+    if (atMaxFires(current)) {
+      debug(`loop #${current.id} — reached maxFires ${current.maxFires}, retiring`);
+      triggerSystem.remove(current.id);
+      if (current.workflow || current.taskBacklog) store.pause(current.id);
+      else store.delete(current.id);
       widget.update();
       return;
     }
-    if (isTaskBacklog) activeTaskBacklogWakes.add(entry.id);
-    const fired = store.fire(entry.id) ?? entry;
+    if (isTaskBacklog) activeTaskBacklogWakes.add(current.id);
+    const fired = store.fire(current.id);
+    if (!fired) return;
 
     const firedAt = Date.now();
     const stateLoop = fired.workflow && getActiveWorkflowStateLoop(fired.workflow);
@@ -250,9 +256,9 @@ export default function (pi: ExtensionAPI) {
       widget.update();
     }
 
-    if (entry.autoTask) {
-      taskProvider?.autoCreateTask(entry).then((taskId) => {
-        if (taskId) debug(`loop #${entry.id} → task #${taskId}`);
+    if (current.autoTask) {
+      taskProvider?.autoCreateTask(current).then((taskId) => {
+        if (taskId) debug(`loop #${current.id} → task #${taskId}`);
       });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -379,6 +379,7 @@ export default function (pi: ExtensionAPI) {
     onDynamicLoopActivated: (entry) => {
       onLoopFire(entry);
     },
+    isTaskSystemReady: () => taskProvider?.isReady() ?? false,
     createWorkflowTask: (entry) => taskProvider?.createWorkflowTask(entry) ?? Promise.resolve(undefined),
     completeWorkflowTask: (taskId, claimId) => taskProvider?.completeWorkflowTask(taskId, claimId) ?? Promise.resolve(false),
     closeWorkflowTask: (taskId, claimId) => taskProvider?.closeWorkflowTask(taskId, claimId) ?? Promise.resolve(false),

--- a/src/loop-reducer.ts
+++ b/src/loop-reducer.ts
@@ -1,4 +1,4 @@
-import type { DynamicLoopState, LoopEntry, Trigger, WorkflowDefinition, WorkflowMonitorWait } from "./types.js";
+import type { DynamicLoopState, LoopEntry, LoopFireOrigin, Trigger, WorkflowDefinition, WorkflowMonitorWait } from "./types.js";
 import { createWorkflowRun, transitionWorkflowRun } from "./workflow-reducer.js";
 
 export const MAX_LOOP_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
@@ -51,7 +51,7 @@ export type LoopReducerEvent =
     source: ReducerSource;
     entityType?: "loop";
     entityId?: string;
-    payload: { id: string };
+    payload: { id: string; origin?: LoopFireOrigin };
   }
   | {
     type: "LOOP_EXPIRED";
@@ -87,6 +87,20 @@ export type LoopReducerEvent =
       outcome: string;
       evidence?: string;
       activeTaskId?: string;
+    };
+  }
+  | {
+    type: "LOOP_WORKFLOW_TERMINAL_TRANSITION";
+    at: number;
+    source: ReducerSource;
+    entityType?: "loop";
+    entityId?: string;
+    payload: {
+      id: string;
+      outcome: string;
+      evidence?: string;
+      activeTaskId?: string;
+      terminal: "completed" | "paused";
     };
   }
   | {
@@ -212,7 +226,7 @@ export function reduceLoopState(state: LoopReducerState, event: LoopReducerEvent
 
   if (event.type === "LOOP_FIRED") {
     loop.fireCount = (loop.fireCount ?? 0) + 1;
-    if (loop.workflow) {
+    if (loop.workflow && event.payload.origin === "scheduler") {
       const stateId = loop.workflow.currentState;
       loop.workflow = {
         ...loop.workflow,
@@ -259,6 +273,37 @@ export function reduceLoopState(state: LoopReducerState, event: LoopReducerEvent
       awaitingUpdate: false,
       lastUpdatedAt: event.at,
     };
+    loop.updatedAt = event.at;
+  }
+
+  if (event.type === "LOOP_WORKFLOW_TERMINAL_TRANSITION") {
+    if (!loop.workflow) return { state, effects: [] };
+    const result = transitionWorkflowRun(loop.workflow, {
+      outcome: event.payload.outcome,
+      evidence: event.payload.evidence,
+      activeTaskId: event.payload.activeTaskId,
+    }, event.at);
+    if (!result.applied || result.terminal !== event.payload.terminal) return { state, effects: [] };
+    if (event.payload.terminal === "completed") {
+      const next = cloneState(state);
+      delete next.loopsById[id];
+      return {
+        state: next,
+        effects: [{ type: "DELETE_LOOP", entityType: "loop", entityId: id, payload: { id } }],
+      };
+    }
+    loop.workflow = result.run;
+    loop.dynamic = {
+      goal: loop.dynamic?.goal ?? loop.prompt,
+      state: result.run.currentState,
+      metrics: loop.dynamic?.metrics,
+      doneCriteria: loop.dynamic?.doneCriteria,
+      iteration: (loop.dynamic?.iteration ?? 0) + 1,
+      nextWakeAt: undefined,
+      awaitingUpdate: false,
+      lastUpdatedAt: event.at,
+    };
+    loop.status = "paused";
     loop.updatedAt = event.at;
   }
 

--- a/src/monitor-manager.ts
+++ b/src/monitor-manager.ts
@@ -103,6 +103,7 @@ export class MonitorManager {
   }
 
   private notifyTerminal(bp: MonitorProcess, monitor: MonitorEntry): void {
+    bp.terminalReady = true;
     if (this.shuttingDown) return;
     for (const callback of bp.terminalCallbacks) callback(monitor);
     bp.terminalCallbacks = [];
@@ -198,6 +199,7 @@ export class MonitorManager {
       waiters: [],
       completionCallbacks: [],
       terminalCallbacks: [],
+      terminalReady: false,
       lastOutputEventAt: 0,
       lastProgressChangeAt: 0,
       pendingOutputLines: 0,
@@ -382,7 +384,6 @@ export class MonitorManager {
       for (const callback of bp.completionCallbacks) callback(bp.entry);
       bp.completionCallbacks = [];
     }
-    this.notifyTerminal(bp, bp.entry);
 
     await new Promise<void>((resolve) => {
       const timer = setTimeout(() => {
@@ -396,6 +397,7 @@ export class MonitorManager {
       });
     });
 
+    this.notifyTerminal(bp, bp.entry);
     bp.completionCallbacks = [];
     for (const resolve of bp.waiters) resolve();
     bp.waiters = [];
@@ -428,7 +430,8 @@ export class MonitorManager {
     const bp = this.processes.get(id);
     if (!bp) return false;
     if (bp.entry.status !== "running") {
-      callback(bp.entry);
+      if (bp.terminalReady) callback(bp.entry);
+      else bp.terminalCallbacks.push(callback);
       return true;
     }
     bp.terminalCallbacks.push(callback);

--- a/src/notification-reducer.ts
+++ b/src/notification-reducer.ts
@@ -15,6 +15,7 @@ export interface ReducerNotification {
   readOnly?: boolean;
   dynamic?: DynamicLoopState;
   workflow?: WorkflowRunState;
+  sessionGeneration?: number;
 }
 
 export interface NotificationReducerState {

--- a/src/runtime/monitor-ondone-runtime.ts
+++ b/src/runtime/monitor-ondone-runtime.ts
@@ -39,6 +39,17 @@ function appendMonitorOutcome(prompt: string, monitor: MonitorEntry | undefined)
   return lines.join("\n");
 }
 
+function isTimeoutAlertLoop(entry: LoopEntry): boolean {
+  const trigger = entry.trigger;
+  return typeof trigger === "object"
+    && trigger?.type === "event"
+    && trigger.source === "monitor:timeout";
+}
+
+function timedOut(monitor: MonitorEntry | undefined): boolean {
+  return monitor?.status === "stopped" && monitor.stopReason === "timeout";
+}
+
 export function createMonitorOnDoneRuntime(options: MonitorOnDoneRuntimeOptions): MonitorOnDoneRuntime {
   const {
     monitorManager,
@@ -78,24 +89,33 @@ export function createMonitorOnDoneRuntime(options: MonitorOnDoneRuntimeOptions)
   });
 
   function register(doneLoop: LoopEntry, monitorId: string): void {
+    const timeoutAlert = isTimeoutAlertLoop(doneLoop);
     const deliver = (monitor?: MonitorEntry) => {
+      const outcome = monitor ?? monitorManager.get(monitorId);
+      if (timeoutAlert && !timedOut(outcome)) {
+        debug?.(`timeout alert loop #${doneLoop.id} — monitor #${monitorId} ended without timing out, expiring`);
+        deleteLoop(doneLoop.id);
+        return;
+      }
       void monitorCompletionCoordinator.dispatch({
         type: "MONITOR_ONDONE_TRIGGERED",
         at: Date.now(),
         source: "monitor",
         entityType: "monitor",
         entityId: monitorId,
-        payload: { loopId: doneLoop.id, monitorId, monitor },
+        payload: { loopId: doneLoop.id, monitorId, monitor: outcome },
       });
     };
 
-    const registered = monitorManager.onComplete(monitorId, deliver);
+    const registered = timeoutAlert
+      ? monitorManager.onTerminal(monitorId, deliver)
+      : monitorManager.onComplete(monitorId, deliver);
     if (registered) return;
 
     const monitor = monitorManager.get(monitorId);
     if (monitor && monitor.status !== "running") {
-      if (monitor.status === "completed" || monitor.status === "error") {
-        deliver();
+      if (timeoutAlert || monitor.status === "completed" || monitor.status === "error") {
+        deliver(monitor);
         return;
       }
       debug?.(`onDone loop #${doneLoop.id} — monitor #${monitorId} already ${monitor.status}, expiring`);

--- a/src/runtime/notification-runtime.ts
+++ b/src/runtime/notification-runtime.ts
@@ -29,6 +29,7 @@ export interface LoopFireEvent {
   dynamic?: DynamicLoopState;
   workflow?: WorkflowRunState;
   monitorOutcome?: MonitorOutcome;
+  sessionGeneration?: number;
 }
 
 export interface PendingNotification extends LoopFireEvent {
@@ -41,6 +42,7 @@ export interface MonitorStartedEvent {
   command: string;
   description?: string;
   timestamp: number;
+  sessionGeneration?: number;
 }
 
 export interface NotificationRuntimeOptions {
@@ -216,6 +218,7 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
     const key = data.recurring ? `loop:${data.loopId}` : `loop:${data.loopId}:${data.timestamp}`;
     return {
       ...data,
+      sessionGeneration: data.sessionGeneration ?? sessionGeneration,
       key,
       message: buildLoopFireMessage(data),
     };
@@ -224,6 +227,7 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
   function buildMonitorStartedNotification(data: MonitorStartedEvent): PendingNotification {
     const label = data.description ?? data.command.slice(0, 80);
     return {
+      sessionGeneration: data.sessionGeneration ?? sessionGeneration,
       loopId: `monitor:${data.monitorId}`,
       prompt: label,
       trigger: { type: "event", source: "monitor:started" },
@@ -237,7 +241,7 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
   }
 
   async function deliverNotification(notification: ReducerNotification): Promise<boolean> {
-    const deliveryGeneration = sessionGeneration;
+    const deliveryGeneration = notification.sessionGeneration ?? sessionGeneration;
     if (notification.autoTask) {
       const pending = await hasPendingTasks();
       if (deliveryGeneration !== sessionGeneration) {
@@ -304,6 +308,10 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
   }
 
   async function queueOrDeliverNotification(data: LoopFireEvent): Promise<void> {
+    if (data.sessionGeneration !== undefined && data.sessionGeneration !== sessionGeneration) {
+      debug?.(`loop:fire #${data.loopId} — stale session generation, dropping wake`);
+      return;
+    }
     const notification = buildPendingNotification(data);
     applyNotificationEvent({
       type: "NOTIFICATION_QUEUED",
@@ -317,6 +325,10 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
   }
 
   async function queueOrDeliverMonitorStarted(data: MonitorStartedEvent): Promise<void> {
+    if (data.sessionGeneration !== undefined && data.sessionGeneration !== sessionGeneration) {
+      debug?.(`monitor:started #${data.monitorId} — stale session generation, dropping wake`);
+      return;
+    }
     const notification = buildMonitorStartedNotification(data);
     await notificationCoordinator.dispatch({
       type: "NOTIFICATION_QUEUED",
@@ -326,6 +338,16 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
       entityId: notification.key,
       payload: { notification },
     });
+    if (notification.sessionGeneration !== sessionGeneration) {
+      applyNotificationEvent({
+        type: "NOTIFICATION_DROPPED",
+        at: Date.now(),
+        source: "session",
+        entityType: "notification",
+        entityId: notification.key,
+        payload: { key: notification.key, reason: "session_switch" },
+      });
+    }
   }
 
   function discardMonitorStarted(monitorId: string): void {

--- a/src/runtime/notification-runtime.ts
+++ b/src/runtime/notification-runtime.ts
@@ -69,6 +69,7 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
     hasPendingMessages: false,
   };
   let flushPromise: Promise<void> | undefined;
+  let sessionGeneration = 0;
 
   type NotificationDispatchResult = {
     kind: "delivery";
@@ -236,8 +237,13 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
   }
 
   async function deliverNotification(notification: ReducerNotification): Promise<boolean> {
+    const deliveryGeneration = sessionGeneration;
     if (notification.autoTask) {
       const pending = await hasPendingTasks();
+      if (deliveryGeneration !== sessionGeneration) {
+        debug?.(`loop:fire #${notification.loopId} — session changed during task lookup, dropping wake`);
+        return false;
+      }
       if (pending === 0) {
         debug?.(`loop:fire #${notification.loopId} — no pending tasks at delivery time, dropping wake`);
         await cleanDoneTasks();
@@ -245,6 +251,10 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
       }
     }
 
+    if (deliveryGeneration !== sessionGeneration) {
+      debug?.(`loop:fire #${notification.loopId} — session changed before delivery, dropping wake`);
+      return false;
+    }
     syncRuntimeState({ agentRunning: true });
     pi.sendMessage({
       customType: "pi-loop",
@@ -331,6 +341,7 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
   }
 
   function clear(reason: "session_shutdown" | "session_switch") {
+    sessionGeneration++;
     syncRuntimeState({ agentRunning: false, hasPendingMessages: false });
     applyNotificationEvent({
       type: "NOTIFICATION_CLEARED",

--- a/src/runtime/session-runtime.ts
+++ b/src/runtime/session-runtime.ts
@@ -184,9 +184,14 @@ export function registerSessionRuntimeHooks(options: SessionRuntimeOptions): voi
   pi.on("session_shutdown", async () => {
     clearWorkflowMonitorWaits();
     await shutdownMonitors();
+    getTriggerSystem().stop();
     stopHeartbeat();
     releaseTaskBacklogWakes();
     notificationRuntime.clear("session_shutdown");
+    setSessionId(undefined);
+    storeUpgraded = false;
+    persistedShown = false;
+    agentStartFireCounts = undefined;
   });
 
   pi.on("session_switch" as never, async (event: SessionSwitchEvent, ctx: ExtensionContext) => {

--- a/src/runtime/session-runtime.ts
+++ b/src/runtime/session-runtime.ts
@@ -15,6 +15,8 @@ export interface SessionRuntimeOptions {
   pi: ExtensionAPI;
   getLoopScope: () => LoopScope;
   getPiLoopEnv: () => string | undefined;
+  getSessionGeneration: () => number;
+  advanceSessionGeneration: () => number;
   recreateSessionStore: (sessionId: string) => void;
   clearAllLoops: () => void;
   getStore: () => LoopStore;
@@ -40,6 +42,8 @@ export function registerSessionRuntimeHooks(options: SessionRuntimeOptions): voi
     pi,
     getLoopScope,
     getPiLoopEnv,
+    getSessionGeneration,
+    advanceSessionGeneration,
     recreateSessionStore,
     clearAllLoops,
     getStore,
@@ -65,6 +69,8 @@ export function registerSessionRuntimeHooks(options: SessionRuntimeOptions): voi
   let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
   let agentStartFireCounts: ReadonlyMap<string, number> | undefined;
 
+  const isCurrentGeneration = (generation: number) => generation === getSessionGeneration();
+
   // The CronScheduler is pump-driven; without this heartbeat it only advances at
   // turn boundaries (turn_start/agent_end), so a loop whose fire time elapses
   // while the agent is idle would never fire and never re-wake the agent. The
@@ -72,11 +78,12 @@ export function registerSessionRuntimeHooks(options: SessionRuntimeOptions): voi
   function ensureHeartbeat(): void {
     if (heartbeatTimer) return;
     heartbeatTimer = setInterval(() => {
-      // Swallow pump failures so a transient error never surfaces as an
-      // unhandled rejection; repaint still runs so cleared harness UI heals.
-      void pumpLoops()
+      const generation = getSessionGeneration();
+      void pumpLoops(generation)
         .catch(() => {})
-        .then(() => widget.update())
+        .then(() => {
+          if (isCurrentGeneration(generation)) widget.update();
+        })
         .catch(() => {});
     }, HEARTBEAT_MS);
     heartbeatTimer.unref?.();
@@ -96,64 +103,77 @@ export function registerSessionRuntimeHooks(options: SessionRuntimeOptions): voi
     storeUpgraded = true;
   }
 
-  async function showPersistedLoops(_isResume = false) {
-    if (persistedShown) return;
+  async function showPersistedLoops(generation = getSessionGeneration()) {
+    if (!isCurrentGeneration(generation) || persistedShown) return;
     persistedShown = true;
     const sessionStartedAt = Date.now();
     migrateTaskBacklogLoops();
+    if (!isCurrentGeneration(generation)) return;
     clearWorkflowMonitorWaits();
-    const loops = getStore().list();
+    const store = getStore();
+    const triggerSystem = getTriggerSystem();
+    const loops = store.list();
     if (loops.length > 0) {
-      getStore().clearExpired();
-      getStore().expireEventLoops(sessionStartedAt);
-      getTriggerSystem().start();
+      store.clearExpired();
+      store.expireEventLoops(sessionStartedAt);
+      triggerSystem.start();
       ensureHeartbeat();
     }
+    if (!isCurrentGeneration(generation)) return;
     await adoptTaskBacklogLoops();
   }
 
-  async function pumpLoops(): Promise<void> {
+  async function pumpLoops(generation = getSessionGeneration()): Promise<void> {
+    const store = getStore();
+    const scheduler = getScheduler();
     const pendingTasks = new Map<string, boolean>();
-    for (const entry of getStore().list()) {
+    for (const entry of store.list()) {
+      if (!isCurrentGeneration(generation)) return;
       if (entry.status !== "active") continue;
       if (!entry.autoTask) continue;
       if (entry.trigger.type !== "cron" && entry.trigger.type !== "hybrid") continue;
-      const nextFire = getScheduler().nextFire(entry.id);
+      const nextFire = scheduler.nextFire(entry.id);
       if (!nextFire || Date.now() < nextFire) continue;
       const pending = await hasPendingTasks();
+      if (!isCurrentGeneration(generation)) return;
       if (pending <= 0) pendingTasks.set(entry.id, true);
     }
-    getScheduler().pump(Date.now(), (entry) => !pendingTasks.has(entry.id));
+    if (!isCurrentGeneration(generation)) return;
+    scheduler.pump(Date.now(), (entry) => !pendingTasks.has(entry.id));
   }
 
   pi.on("session_start", async (_event, ctx) => {
+    const generation = getSessionGeneration();
     setLatestCtx(ctx);
     setSessionId(ctx.sessionManager.getSessionId());
     widget.setUICtx(ctx.ui);
     upgradeStoreIfNeeded(ctx);
     ensureHeartbeat();
-    await showPersistedLoops();
-    widget.update();
+    await showPersistedLoops(generation);
+    if (isCurrentGeneration(generation)) widget.update();
   });
 
   pi.on("turn_start", async (_event, ctx) => {
+    const generation = getSessionGeneration();
     setLatestCtx(ctx);
     setSessionId(ctx.sessionManager.getSessionId());
     widget.setUICtx(ctx.ui);
     upgradeStoreIfNeeded(ctx);
     ensureHeartbeat();
-    await showPersistedLoops();
+    await showPersistedLoops(generation);
+    if (!isCurrentGeneration(generation)) return;
     widget.update();
-    await pumpLoops();
+    await pumpLoops(generation);
   });
 
   pi.on("before_agent_start", async (_event, ctx) => {
+    const generation = getSessionGeneration();
     setLatestCtx(ctx);
     widget.setUICtx(ctx.ui);
     upgradeStoreIfNeeded(ctx);
     ensureHeartbeat();
-    await showPersistedLoops();
-    widget.update();
+    await showPersistedLoops(generation);
+    if (isCurrentGeneration(generation)) widget.update();
   });
 
   pi.on("agent_start", async (_event, ctx) => {
@@ -167,6 +187,7 @@ export function registerSessionRuntimeHooks(options: SessionRuntimeOptions): voi
   });
 
   pi.on("agent_end", async (_event, ctx) => {
+    const generation = getSessionGeneration();
     setLatestCtx(ctx);
     widget.setUICtx(ctx.ui);
     notificationRuntime.syncRuntimeState({
@@ -175,15 +196,18 @@ export function registerSessionRuntimeHooks(options: SessionRuntimeOptions): voi
     });
     releaseTaskBacklogWakes();
     await cleanupTaskBacklogLoops();
+    if (!isCurrentGeneration(generation)) return;
     await adoptTaskBacklogLoops(agentStartFireCounts);
+    if (!isCurrentGeneration(generation)) return;
     agentStartFireCounts = undefined;
     await flushPendingNotifications({ ignorePendingMessages: true });
-    await pumpLoops();
+    if (!isCurrentGeneration(generation)) return;
+    await pumpLoops(generation);
   });
 
   pi.on("session_shutdown", async () => {
+    advanceSessionGeneration();
     clearWorkflowMonitorWaits();
-    await shutdownMonitors();
     getTriggerSystem().stop();
     stopHeartbeat();
     releaseTaskBacklogWakes();
@@ -192,28 +216,30 @@ export function registerSessionRuntimeHooks(options: SessionRuntimeOptions): voi
     storeUpgraded = false;
     persistedShown = false;
     agentStartFireCounts = undefined;
+    await shutdownMonitors();
   });
 
   pi.on("session_switch" as never, async (event: SessionSwitchEvent, ctx: ExtensionContext) => {
+    const generation = advanceSessionGeneration();
     clearWorkflowMonitorWaits();
-    await shutdownMonitors();
-    setLatestCtx(ctx);
-    widget.setUICtx(ctx.ui);
     getTriggerSystem().stop();
     stopHeartbeat();
     notificationRuntime.clear("session_switch");
     releaseTaskBacklogWakes();
     setSessionId(undefined);
-
-    const isResume = event?.reason === "resume";
     storeUpgraded = false;
     persistedShown = false;
+    await shutdownMonitors();
+    if (!isCurrentGeneration(generation)) return;
 
+    setLatestCtx(ctx);
+    widget.setUICtx(ctx.ui);
+    const isResume = event?.reason === "resume";
     setSessionId(ctx.sessionManager.getSessionId());
     upgradeStoreIfNeeded(ctx);
     if (!isResume && getLoopScope() === "memory") clearAllLoops();
-    await showPersistedLoops(isResume);
-    widget.update();
+    await showPersistedLoops(generation);
+    if (isCurrentGeneration(generation)) widget.update();
   });
 
   pi.on("tool_execution_end", async (event: unknown, ctx: ExtensionContext) => {

--- a/src/runtime/session-runtime.ts
+++ b/src/runtime/session-runtime.ts
@@ -28,8 +28,8 @@ export interface SessionRuntimeOptions {
   notificationRuntime: NotificationRuntime;
   flushPendingNotifications: (options?: { ignorePendingMessages?: boolean }) => Promise<void>;
   migrateTaskBacklogLoops: () => number;
-  cleanupTaskBacklogLoops: () => Promise<number>;
-  adoptTaskBacklogLoops: (baselineFireCounts?: ReadonlyMap<string, number>) => Promise<number>;
+  cleanupTaskBacklogLoops: (isCurrent?: () => boolean) => Promise<number>;
+  adoptTaskBacklogLoops: (baselineFireCounts?: ReadonlyMap<string, number>, isCurrent?: () => boolean) => Promise<number>;
   releaseTaskBacklogWakes: () => void;
   clearWorkflowMonitorWaits: () => void;
   shutdownMonitors: () => Promise<void>;
@@ -120,7 +120,7 @@ export function registerSessionRuntimeHooks(options: SessionRuntimeOptions): voi
       ensureHeartbeat();
     }
     if (!isCurrentGeneration(generation)) return;
-    await adoptTaskBacklogLoops();
+    await adoptTaskBacklogLoops(undefined, () => isCurrentGeneration(generation));
   }
 
   async function pumpLoops(generation = getSessionGeneration()): Promise<void> {
@@ -195,9 +195,9 @@ export function registerSessionRuntimeHooks(options: SessionRuntimeOptions): voi
       hasPendingMessages: ctx.hasPendingMessages(),
     });
     releaseTaskBacklogWakes();
-    await cleanupTaskBacklogLoops();
+    await cleanupTaskBacklogLoops(() => isCurrentGeneration(generation));
     if (!isCurrentGeneration(generation)) return;
-    await adoptTaskBacklogLoops(agentStartFireCounts);
+    await adoptTaskBacklogLoops(agentStartFireCounts, () => isCurrentGeneration(generation));
     if (!isCurrentGeneration(generation)) return;
     agentStartFireCounts = undefined;
     await flushPendingNotifications({ ignorePendingMessages: true });

--- a/src/runtime/task-backlog-runtime.ts
+++ b/src/runtime/task-backlog-runtime.ts
@@ -125,12 +125,14 @@ export function createTaskBacklogRuntime(options: TaskBacklogRuntimeOptions): Ta
     if (isCurrent && !isCurrent()) return 0;
     if (pending <= 0) return 0;
 
+    let adopted = 0;
     for (const entry of backlogLoops) {
-      if (isCurrent && !isCurrent()) return 0;
+      if (isCurrent && !isCurrent()) break;
       debug?.(`task backlog loop #${entry.id} — adopting ${pending} unfinished task(s)`);
       await adoptLoop(entry);
+      adopted++;
     }
-    return backlogLoops.length;
+    return adopted;
   }
 
   async function cleanupTaskBacklogLoops(isCurrent?: () => boolean): Promise<number> {

--- a/src/runtime/task-backlog-runtime.ts
+++ b/src/runtime/task-backlog-runtime.ts
@@ -52,8 +52,8 @@ export interface TaskBacklogRuntimeOptions {
 }
 
 export interface TaskBacklogRuntime {
-  cleanupTaskBacklogLoops(): Promise<number>;
-  adoptTaskBacklogLoops(baselineFireCounts?: ReadonlyMap<string, number>): Promise<number>;
+  cleanupTaskBacklogLoops(isCurrent?: () => boolean): Promise<number>;
+  adoptTaskBacklogLoops(baselineFireCounts?: ReadonlyMap<string, number>, isCurrent?: () => boolean): Promise<number>;
   evaluateTaskBacklog(taskStore?: TaskStore, pendingCount?: number): Promise<{ entry?: LoopEntry; created: boolean; cleaned: number }>;
   isAutoTaskWorkerLoop(entry: LoopEntry): boolean;
   isTaskBacklogLoop(entry: LoopEntry): boolean;
@@ -112,26 +112,34 @@ export function createTaskBacklogRuntime(options: TaskBacklogRuntimeOptions): Ta
     emitLoopAutodeleted?.(buildLoopAutodeletedPayload(entry, pendingCount));
   }
 
-  async function adoptTaskBacklogLoops(baselineFireCounts?: ReadonlyMap<string, number>): Promise<number> {
+  async function adoptTaskBacklogLoops(
+    baselineFireCounts?: ReadonlyMap<string, number>,
+    isCurrent?: () => boolean,
+  ): Promise<number> {
+    if (isCurrent && !isCurrent()) return 0;
     const backlogLoops = getLoops().filter((entry) => isTaskBacklogLoop(entry)
       && (baselineFireCounts === undefined || (entry.fireCount ?? 0) <= (baselineFireCounts.get(entry.id) ?? 0)));
     if (backlogLoops.length === 0) return 0;
 
     const pending = await hasPendingTasks();
+    if (isCurrent && !isCurrent()) return 0;
     if (pending <= 0) return 0;
 
     for (const entry of backlogLoops) {
+      if (isCurrent && !isCurrent()) return 0;
       debug?.(`task backlog loop #${entry.id} — adopting ${pending} unfinished task(s)`);
       await adoptLoop(entry);
     }
     return backlogLoops.length;
   }
 
-  async function cleanupTaskBacklogLoops(): Promise<number> {
+  async function cleanupTaskBacklogLoops(isCurrent?: () => boolean): Promise<number> {
+    if (isCurrent && !isCurrent()) return 0;
     const backlogLoops = getLoops().filter(isTaskBacklogLoop);
     if (backlogLoops.length === 0) return 0;
 
     const pending = await hasPendingTasks();
+    if (isCurrent && !isCurrent()) return 0;
     if (pending < 0 || pending > 0) return 0;
 
     const deletedLoopIds = backlogLoops.map((entry) => entry.id);

--- a/src/runtime/task-provider-runtime.ts
+++ b/src/runtime/task-provider-runtime.ts
@@ -17,7 +17,8 @@ export interface TaskProviderRuntimeOptions {
   resolveStorePath: () => string | undefined;
   getSessionId: () => string | undefined;
   evaluateTaskBacklog: (taskStore: TaskStore, pendingCount: number) => Promise<TaskBacklogResult>;
-  onReady?: () => Promise<void> | void;
+  onReady?: (detectionGeneration?: number) => Promise<void> | void;
+  getSessionGeneration?: () => number;
   updateWidget: () => void;
   isStaleExtensionContextError: (error: unknown) => boolean;
   debug?: (...args: unknown[]) => void;
@@ -44,6 +45,7 @@ export function createTaskProviderRuntime(options: TaskProviderRuntimeOptions): 
     getSessionId,
     evaluateTaskBacklog,
     onReady,
+    getSessionGeneration,
     updateWidget,
     isStaleExtensionContextError,
     debug,
@@ -56,12 +58,13 @@ export function createTaskProviderRuntime(options: TaskProviderRuntimeOptions): 
   const nativeTaskStores = new Map<string, TaskStore>();
   let nativeToolsRegistered = false;
   let readyNotified = false;
+  let detectionGeneration = getSessionGeneration?.();
 
   function notifyReady(): void {
     if (readyNotified) return;
     readyNotified = true;
     Promise.resolve()
-      .then(() => onReady?.())
+      .then(() => onReady?.(detectionGeneration))
       .catch((error) => debug?.("task provider ready callback failed", error));
   }
 
@@ -95,6 +98,7 @@ export function createTaskProviderRuntime(options: TaskProviderRuntimeOptions): 
     },
     onDetectionStarted: () => {
       detectionSettled = false;
+      detectionGeneration = getSessionGeneration?.();
     },
     onDetectionSettled: () => {
       detectionSettled = true;

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,7 +1,7 @@
 import { computeJitter, cronToNextFire } from "./loop-parse.js";
 import type { LoopStore } from "./store.js";
 import type { LoopEntry } from "./types.js";
-import { atWorkflowStateFireLimit, getActiveWorkflowStateLoop } from "./workflow-reducer.js";
+import { atWorkflowStateFireLimit, getActiveWorkflowStateLoop, isTerminalWorkflowRun } from "./workflow-reducer.js";
 
 function computeNextFire(entry: LoopEntry): Date {
   const workflowLoop = entry.workflow && getActiveWorkflowStateLoop(entry.workflow);
@@ -26,7 +26,7 @@ export class CronScheduler {
   start(): void {
     for (const storedEntry of this.store.list()) {
       let entry = storedEntry;
-      if (entry.status !== "active" || entry.workflow?.waitingMonitor) continue;
+      if (entry.status !== "active" || entry.workflow?.waitingMonitor || isTerminalWorkflowRun(entry.workflow)) continue;
       if (entry.trigger.type === "cron" || entry.trigger.type === "hybrid" || entry.trigger.type === "dynamic") {
         if (entry.trigger.type === "dynamic" && entry.dynamic?.awaitingUpdate && !this.fireTimes.has(entry.id)) {
           entry = this.store.updateDynamic(entry.id, {
@@ -47,7 +47,7 @@ export class CronScheduler {
   }
 
   add(entry: LoopEntry): void {
-    if (!entry.workflow?.waitingMonitor && (entry.trigger.type === "cron" || entry.trigger.type === "hybrid" || entry.trigger.type === "dynamic")) {
+    if (!entry.workflow?.waitingMonitor && !isTerminalWorkflowRun(entry.workflow) && (entry.trigger.type === "cron" || entry.trigger.type === "hybrid" || entry.trigger.type === "dynamic")) {
       this.armTimer(entry);
     }
   }
@@ -93,7 +93,7 @@ export class CronScheduler {
       if (now < fireTime) continue;
 
       const entry = this.store.get(id);
-      if (entry?.status !== "active" || entry.workflow?.waitingMonitor) {
+      if (entry?.status !== "active" || entry.workflow?.waitingMonitor || isTerminalWorkflowRun(entry.workflow)) {
         this.fireTimes.delete(id);
         continue;
       }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,6 +1,6 @@
 import { computeJitter, cronToNextFire } from "./loop-parse.js";
 import type { LoopStore } from "./store.js";
-import type { LoopEntry } from "./types.js";
+import type { LoopEntry, LoopFireOrigin } from "./types.js";
 import { atWorkflowStateFireLimit, getActiveWorkflowStateLoop, isTerminalWorkflowRun } from "./workflow-reducer.js";
 
 function computeNextFire(entry: LoopEntry): Date {
@@ -20,7 +20,7 @@ export class CronScheduler {
 
   constructor(
     private store: LoopStore,
-    private onFire: (entry: LoopEntry) => void,
+    private onFire: (entry: LoopEntry, origin: LoopFireOrigin) => void,
   ) {}
 
   start(): void {
@@ -107,7 +107,7 @@ export class CronScheduler {
         continue;
       }
 
-      this.onFire(entry);
+      this.onFire(entry, "scheduler");
 
       const fresh = this.store.get(id);
       if (!fresh) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { type LoopReducerEvent, type LoopReducerState, reduceLoopState } from "./loop-reducer.js";
 import { ReducerBackedStore } from "./reducer-backed-store.js";
-import type { DynamicLoopState, LoopDeletionTombstone, LoopDeletionTombstoneInput, LoopEntry, LoopStoreData, Trigger, WorkflowDefinition, WorkflowMonitorWait, WorkflowTerminalStatus } from "./types.js";
+import type { DynamicLoopState, LoopDeletionTombstone, LoopDeletionTombstoneInput, LoopEntry, LoopFireOrigin, LoopStoreData, Trigger, WorkflowDefinition, WorkflowMonitorWait, WorkflowTerminalStatus } from "./types.js";
 import { isTerminalWorkflowRun, transitionWorkflowRun, validateWorkflowDefinition, type WorkflowTransitionFailure, type WorkflowTransitionInput } from "./workflow-reducer.js";
 
 const LOOPS_DIR = join(homedir(), ".pi", "loops");
@@ -106,7 +106,7 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
     });
   }
 
-  fire(id: string): LoopEntry | undefined {
+  fire(id: string, origin: LoopFireOrigin = "scheduler"): LoopEntry | undefined {
     return this.withLock(() => {
       const entry = this.entries.get(id);
       if (entry?.status !== "active" || isTerminalWorkflowRun(entry?.workflow)) return undefined;
@@ -116,7 +116,7 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
         source: "system",
         entityType: "loop",
         entityId: id,
-        payload: { id },
+        payload: { id, origin },
       });
       return this.entries.get(id);
     });
@@ -247,8 +247,9 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
         return { applied: false, error: result.error, failure: result.failure };
       }
 
+      const eventType = result.terminal ? "LOOP_WORKFLOW_TERMINAL_TRANSITION" : "LOOP_WORKFLOW_TRANSITION";
       this.applyReducerEvent({
-        type: "LOOP_WORKFLOW_TRANSITION",
+        type: eventType,
         at: result.run.stateEnteredAt,
         source: "tool",
         entityType: "loop",
@@ -258,32 +259,29 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
           outcome: input.outcome,
           evidence: input.evidence,
           activeTaskId: input.activeTaskId,
+          ...(result.terminal ? { terminal: result.terminal } : {}),
         },
-      });
-      const transitioned = this.entries.get(id);
-      if (!transitioned) return { applied: false, error: `Workflow #${id} disappeared during transition` };
-      if (result.terminal === "completed") {
-        this.applyReducerEvent({
-          type: "LOOP_DELETED",
-          at: result.run.stateEnteredAt,
-          source: "tool",
-          entityType: "loop",
-          entityId: id,
-          payload: { id },
-        });
-        return { entry: transitioned, applied: true, terminal: result.terminal };
+      } as LoopReducerEvent);
+      if (result.terminal) {
+        const terminalEntry: LoopEntry = {
+          ...entry,
+          status: result.terminal === "paused" ? "paused" : entry.status,
+          updatedAt: result.run.stateEnteredAt,
+          dynamic: {
+            goal: entry.dynamic?.goal ?? entry.prompt,
+            state: result.run.currentState,
+            metrics: entry.dynamic?.metrics,
+            doneCriteria: entry.dynamic?.doneCriteria,
+            iteration: (entry.dynamic?.iteration ?? 0) + 1,
+            nextWakeAt: undefined,
+            awaitingUpdate: false,
+            lastUpdatedAt: result.run.stateEnteredAt,
+          },
+          workflow: result.run,
+        };
+        return { entry: terminalEntry, applied: true, terminal: result.terminal };
       }
-      if (result.terminal === "paused") {
-        this.applyReducerEvent({
-          type: "LOOP_PAUSED",
-          at: result.run.stateEnteredAt,
-          source: "tool",
-          entityType: "loop",
-          entityId: id,
-          payload: { id },
-        });
-      }
-      return { entry: this.entries.get(id), applied: true, terminal: result.terminal };
+      return { entry: this.entries.get(id), applied: true };
     });
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -109,7 +109,7 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
   fire(id: string): LoopEntry | undefined {
     return this.withLock(() => {
       const entry = this.entries.get(id);
-      if (!entry) return undefined;
+      if (entry?.status !== "active" || isTerminalWorkflowRun(entry?.workflow)) return undefined;
       this.applyReducerEvent({
         type: "LOOP_FIRED",
         at: Date.now(),
@@ -260,6 +260,29 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
           activeTaskId: input.activeTaskId,
         },
       });
+      const transitioned = this.entries.get(id);
+      if (!transitioned) return { applied: false, error: `Workflow #${id} disappeared during transition` };
+      if (result.terminal === "completed") {
+        this.applyReducerEvent({
+          type: "LOOP_DELETED",
+          at: result.run.stateEnteredAt,
+          source: "tool",
+          entityType: "loop",
+          entityId: id,
+          payload: { id },
+        });
+        return { entry: transitioned, applied: true, terminal: result.terminal };
+      }
+      if (result.terminal === "paused") {
+        this.applyReducerEvent({
+          type: "LOOP_PAUSED",
+          at: result.run.stateEnteredAt,
+          source: "tool",
+          entityType: "loop",
+          entityId: id,
+          payload: { id },
+        });
+      }
       return { entry: this.entries.get(id), applied: true, terminal: result.terminal };
     });
   }

--- a/src/tools/loop-tools.ts
+++ b/src/tools/loop-tools.ts
@@ -296,7 +296,8 @@ A completed iteration, unchanged result, or temporarily empty check is not a rea
       if (trigger.type === "event") backlogEventSource = trigger.source;
       else if (trigger.type === "hybrid") backlogEventSource = trigger.event.source;
       let backlogError: string | undefined;
-      if (taskBacklog && recurring === false) backlogError = "taskBacklog loops must be recurring.";
+      if (taskBacklog && autoTask) backlogError = "taskBacklog loops cannot enable autoTask; backlog workers adopt existing tasks instead of creating more.";
+      else if (taskBacklog && recurring === false) backlogError = "taskBacklog loops must be recurring.";
       else if (taskBacklog && backlogEventSource !== "tasks:created") {
         backlogError = 'taskBacklog loops require a "tasks:created" event trigger. For a broad goal, use trigger "idle" with triggerType "idle" and omit taskBacklog.';
       }

--- a/src/tools/monitor-tools.ts
+++ b/src/tools/monitor-tools.ts
@@ -69,7 +69,7 @@ export function registerMonitorTools(options: MonitorToolsOptions): void {
   pi.registerTool({ name: "MonitorCreate", label: "MonitorCreate",
   renderShell: "self",
   renderCall: hideToolTranscript,
-  renderResult: hideToolTranscript, description: `Run a long command in the background while the agent continues. Use MonitorList for status/output; do not poll with shell sleep loops.\n\nPass onDone to create one completion wake for success, failure, or timeout. Pass workflowId to pause its workflow until a terminal result. Commands may emit JSONL progress as {"progress":{"current":42,"total":100,"message":"..."}}; otherwise use MonitorUpdate.`, promptGuidelines: ["Use MonitorCreate for builds, CI checks, experiments, and other commands that need not block the turn.", "Use onDone when the agent must resume automatically after completion; do not create a separate polling loop.", "For an active workflow, use workflowId instead of onDone and await its completion wake."], parameters: Type.Object({
+  renderResult: hideToolTranscript, description: `Run a long command in the background while the agent continues. Use MonitorList for status/output; do not poll with shell sleep loops.\n\nTimed monitors always wake the agent if they time out. Pass onDone to create a completion wake for success, failure, or timeout. Pass workflowId to pause its workflow until a terminal result. Commands may emit JSONL progress as {"progress":{"current":42,"total":100,"message":"..."}}; otherwise use MonitorUpdate.`, promptGuidelines: ["Use MonitorCreate for builds, CI checks, experiments, and other commands that need not block the turn.", "Use onDone when the agent must resume automatically after success or failure; timed monitors already alert on timeout.", "For an active workflow, use workflowId instead of onDone and await its completion wake."], parameters: Type.Object({
     command: Type.String({ description: "Shell command to run in background" }),
     description: Type.Optional(Type.String({ description: "Human-readable description" })),
     timeout: Type.Optional(Type.Number({ description: "Auto-stop after N ms (default: 300000, 0 = no timeout)", default: 300000 })),
@@ -131,6 +131,15 @@ export function registerMonitorTools(options: MonitorToolsOptions): void {
       const doneLoop = store.create(doneTrigger, params.onDone, { recurring: false });
       handleMonitorDoneLoop(doneLoop, entry.id);
       onDoneMsg = `\nCompletion wake loop #${doneLoop.id}: fires when the monitor completes — no polling needed`;
+    } else if (!workflow && entry.timeout > 0) {
+      const timeoutTrigger: Trigger = { type: "event", source: "monitor:timeout", filter: JSON.stringify({ monitorId: entry.id }) };
+      const timeoutLoop = store.create(
+        timeoutTrigger,
+        `Monitor #${entry.id} timed out. Inspect MonitorList, report the failure, and decide whether to retry with a smaller bounded command.`,
+        { recurring: false },
+      );
+      handleMonitorDoneLoop(timeoutLoop, entry.id);
+      onDoneMsg = `\nTimeout alert loop #${timeoutLoop.id}: wakes the agent only if the monitor times out`;
     }
 
     return Promise.resolve(textResult(
@@ -145,7 +154,7 @@ export function registerMonitorTools(options: MonitorToolsOptions): void {
         expanded: [
           `Command: ${entry.command}`,
           `Timeout: ${params.timeout ? `${params.timeout / 1000}s` : "none"}`,
-          workflow ? `Workflow #${workflow.id}: waiting for terminal monitor outcome` : params.onDone ? "Completion wake: enabled" : "Completion wake: off",
+          workflow ? `Workflow #${workflow.id}: waiting for terminal monitor outcome` : params.onDone ? "Completion wake: enabled" : entry.timeout > 0 ? "Timeout alert: enabled" : "Completion wake: off",
         ],
       },
     ));

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -191,8 +191,17 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
         dynamic: { goal: params.goal, state: parsed.definition.initialState, iteration: 0 },
         workflow: parsed.definition,
       });
-      const createdTaskId = await createWorkflowTask?.(entry);
+      const requiresInitialTask = Boolean(entry.workflow && initialState?.task && !initialState.terminal);
+      const createdTaskId = requiresInitialTask ? await createWorkflowTask?.(entry) : undefined;
       let taskId: string | undefined;
+      if (requiresInitialTask && !createdTaskId) {
+        getStore().delete(entry.id);
+        const message = `Workflow #${entry.id} was not created because its initial task could not be created. Retry after the task provider is available.`;
+        updateWidget();
+        return textResult(message, {
+          kind: "workflow", action: "create", tone: "error", summary: `Workflow #${entry.id} task creation failed`, expanded: [message],
+        });
+      }
       if (createdTaskId && entry.workflow) {
         const bound = getStore().setWorkflowActiveTask(entry.id, createdTaskId, {
           currentState: entry.workflow.currentState,
@@ -204,7 +213,8 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
           taskId = createdTaskId;
         } else {
           const closed = await closeWorkflowTask?.(createdTaskId);
-          const message = `Workflow #${entry.id} changed while initial task #${createdTaskId} was created; task cleanup ${closed ? "succeeded" : "failed"}. Inspect LoopList before retrying.`;
+          getStore().delete(entry.id);
+          const message = `Workflow #${entry.id} changed while initial task #${createdTaskId} was created; task cleanup ${closed ? "succeeded" : "failed"}.`;
           updateWidget();
           return textResult(message, {
             kind: "workflow", action: "create", tone: "error", summary: `Workflow #${entry.id} task binding rejected`, expanded: [message],
@@ -261,6 +271,7 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
       const transitionInput = { outcome: params.outcome, evidence: params.evidence };
       const currentEntry = store.get(params.id);
       const sourceTaskId = currentEntry?.workflow?.activeTaskId;
+      let destinationTaskId: string | undefined;
       if (currentEntry?.workflow) {
         const preview = transitionWorkflowRun(currentEntry.workflow, transitionInput, Date.now());
         if (!preview.applied) {
@@ -270,9 +281,20 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
             { kind: "workflow", action: "transition", tone: "error", summary: `Workflow #${params.id} remains in ${currentEntry.workflow.currentState}`, expanded: [error] },
           );
         }
+        const destinationState = preview.run.definition.states[preview.run.currentState];
+        if (destinationState?.task && !destinationState.terminal) {
+          destinationTaskId = await createWorkflowTask?.({ ...currentEntry, workflow: preview.run });
+          if (!destinationTaskId) {
+            const message = `Workflow #${params.id} did not transition because its destination task could not be created. Retry after the task provider is available.`;
+            return textResult(message, {
+              kind: "workflow", action: "transition", tone: "error", summary: `Workflow #${params.id} destination task creation failed`, expanded: [message],
+            });
+          }
+        }
       }
       const sourceTaskClosed = sourceTaskId ? await completeWorkflowTask?.(sourceTaskId, params.claimId) : undefined;
       if (sourceTaskId && !sourceTaskClosed) {
+        if (destinationTaskId) await closeWorkflowTask?.(destinationTaskId);
         const message = `Source task #${sourceTaskId} could not be completed; reclaim it and pass claimId before retrying the workflow transition.`;
         return textResult(message, {
           kind: "workflow", action: "transition", tone: "error", summary: `Workflow #${params.id} transition blocked by task #${sourceTaskId}`, expanded: [message],
@@ -287,6 +309,7 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
         : undefined;
       const result = store.transitionWorkflow(params.id, transitionInput, expected);
       if (!result.applied || !result.entry) {
+        if (destinationTaskId) await closeWorkflowTask?.(destinationTaskId);
         const current = store.get(params.id);
         if (current?.workflow) {
           const error = result.error ?? "unknown transition error";
@@ -330,25 +353,23 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
       }
 
       const resumedEntry = entry.status === "paused" ? store.resume(entry.id) ?? entry : entry;
-      const existingTaskId = resumedEntry.workflow?.activeTaskId;
-      const createdTaskId = existingTaskId ? undefined : await createWorkflowTask?.(resumedEntry);
       let updatedEntry = resumedEntry;
-      if (createdTaskId && resumedEntry.workflow) {
-        const bound = store.setWorkflowActiveTask(resumedEntry.id, createdTaskId, {
+      if (destinationTaskId && resumedEntry.workflow) {
+        const bound = store.setWorkflowActiveTask(resumedEntry.id, destinationTaskId, {
           currentState: resumedEntry.workflow.currentState,
           transitionSeq: resumedEntry.workflow.transitionSeq,
           activeTaskId: resumedEntry.workflow.activeTaskId,
         });
         if (!bound) {
-          await closeWorkflowTask?.(createdTaskId);
-          const message = `Workflow #${resumedEntry.id} changed while destination task #${createdTaskId} was created; the task was closed. Inspect LoopList before retrying.`;
+          await closeWorkflowTask?.(destinationTaskId);
+          const message = `Workflow #${resumedEntry.id} changed while destination task #${destinationTaskId} was created; the task was closed. Inspect LoopList before retrying.`;
           return textResult(message, {
             kind: "workflow", action: "transition", tone: "error", summary: `Workflow #${resumedEntry.id} task binding rejected`, expanded: [message],
           });
         }
         updatedEntry = bound;
       }
-      const taskId = existingTaskId ?? createdTaskId;
+      const taskId = destinationTaskId;
       getTriggerSystem().add(updatedEntry);
       updateWidget();
       if (stateLoopStartsImmediately(updatedEntry)) onDynamicLoopActivated?.(updatedEntry);

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -46,6 +46,7 @@ export interface WorkflowToolsOptions {
   getTriggerSystem: () => TriggerSystemLike;
   updateWidget: () => void;
   onDynamicLoopActivated?: (entry: LoopEntry) => void;
+  isTaskSystemReady: () => boolean;
   createWorkflowTask?: (entry: LoopEntry) => Promise<string | undefined>;
   completeWorkflowTask?: (taskId: string, claimId?: string) => Promise<boolean>;
   closeWorkflowTask?: (taskId: string, claimId?: string) => Promise<boolean>;
@@ -138,6 +139,7 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
     getTriggerSystem,
     updateWidget,
     onDynamicLoopActivated,
+    isTaskSystemReady,
     createWorkflowTask,
     completeWorkflowTask,
     closeWorkflowTask,
@@ -172,6 +174,14 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
           tone: "error",
           summary: "Workflow definition rejected",
           expanded: [parsed.error ?? "unknown validation error", "Expand the tool result for a valid definition skeleton."],
+        });
+      }
+
+      const initialState = parsed.definition.states[parsed.definition.initialState];
+      if (initialState?.task && !isTaskSystemReady()) {
+        const message = "Task system is still initializing; retry WorkflowCreate after task-provider detection settles.";
+        return textResult(message, {
+          kind: "workflow", action: "create", tone: "error", summary: "Workflow creation deferred", expanded: [message],
         });
       }
 

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -291,7 +291,6 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
       const entry = result.entry;
       getTriggerSystem().remove(entry.id);
       if (result.terminal === "completed") {
-        store.delete(entry.id);
         updateWidget();
         return textResult(
           `Workflow #${entry.id} completed and deleted\nFinal transition: ${entry.workflow?.lastTransition?.from ?? "?"} → ${entry.workflow?.currentState ?? "?"}\nNext: no further workflow transition is needed.`,
@@ -306,7 +305,6 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
         );
       }
       if (result.terminal === "paused") {
-        store.pause(entry.id);
         updateWidget();
         return textResult(
           `Workflow #${entry.id} paused\nFinal state: ${entry.workflow?.currentState ?? "?"}\nNext: inspect it with LoopList. Terminal workflow states cannot be resumed; delete the loop when it is no longer needed.`,

--- a/src/trigger-system.ts
+++ b/src/trigger-system.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { atMaxFires } from "./loop-reducer.js";
 import type { CronScheduler } from "./scheduler.js";
 import type { LoopStore } from "./store.js";
-import type { LoopEntry } from "./types.js";
+import type { LoopEntry, LoopFireOrigin } from "./types.js";
 import { isTerminalWorkflowRun } from "./workflow-reducer.js";
 
 export class TriggerSystem {
@@ -14,7 +14,7 @@ export class TriggerSystem {
     private pi: ExtensionAPI,
     private scheduler: CronScheduler,
     private store: LoopStore,
-    private onFire: (entry: LoopEntry) => void,
+    private onFire: (entry: LoopEntry, origin: LoopFireOrigin) => void,
   ) {}
 
   start(): void {
@@ -118,7 +118,7 @@ export class TriggerSystem {
     }
 
     this.lastFireTime.set(current.id, Date.now());
-    this.onFire(current);
+    this.onFire(current, "event");
 
     const fresh = this.store.get(entry.id);
     if (!fresh) {

--- a/src/trigger-system.ts
+++ b/src/trigger-system.ts
@@ -3,6 +3,7 @@ import { atMaxFires } from "./loop-reducer.js";
 import type { CronScheduler } from "./scheduler.js";
 import type { LoopStore } from "./store.js";
 import type { LoopEntry } from "./types.js";
+import { isTerminalWorkflowRun } from "./workflow-reducer.js";
 
 export class TriggerSystem {
   private eventSubscriptions = new Map<string, Map<string, () => void>>();
@@ -19,7 +20,7 @@ export class TriggerSystem {
   start(): void {
     this.scheduler.start();
     for (const entry of this.store.list()) {
-      if (entry.status !== "active") continue;
+      if (entry.status !== "active" || isTerminalWorkflowRun(entry.workflow)) continue;
       if (entry.trigger.type !== "event" && entry.trigger.type !== "hybrid") continue;
       const event = entry.trigger.type === "hybrid" ? entry.trigger.event : entry.trigger;
       this.subscribeEvent(entry, event.source, event.filter);
@@ -37,6 +38,7 @@ export class TriggerSystem {
   }
 
   add(entry: LoopEntry): void {
+    if (isTerminalWorkflowRun(entry.workflow)) return;
     if (entry.trigger.type === "cron" || entry.trigger.type === "hybrid" || entry.trigger.type === "dynamic") {
       this.scheduler.add(entry);
     }
@@ -110,7 +112,7 @@ export class TriggerSystem {
 
   private fireLoop(entry: LoopEntry): void {
     const current = this.store.get(entry.id);
-    if (!current || current.status !== "active") {
+    if (current?.status !== "active" || isTerminalWorkflowRun(current?.workflow)) {
       this.remove(entry.id);
       return;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export type LoopDeletionTombstoneInput = Omit<LoopDeletionTombstone, "id" | "del
 
 export type LoopStatus = "active" | "paused";
 
+export type LoopFireOrigin = "scheduler" | "event" | "dynamic" | "monitor";
+
 export interface CronTrigger {
   type: "cron";
   schedule: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,6 +168,7 @@ export interface MonitorProcess {
   waiters: Array<() => void>;
   completionCallbacks: Array<(monitor: MonitorEntry) => void>;
   terminalCallbacks: Array<(monitor: MonitorEntry) => void>;
+  terminalReady: boolean;
   lastOutputEventAt: number;
   lastProgressChangeAt: number;
   progressChangeTimer?: ReturnType<typeof setTimeout>;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1894,7 +1894,7 @@ describe("monitor tool wrappers", () => {
       payload: expect.objectContaining({
         loopId: workflowId,
         monitorOutcome: expect.objectContaining({ monitorId: "1", status: "completed" }),
-        workflow: expect.objectContaining({ stateFireCounts: { validate: 2 } }),
+        workflow: expect.objectContaining({ stateFireCounts: {} }),
       }),
     })]);
     expect(sentCustomMessages).toHaveLength(1);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1880,7 +1880,9 @@ describe("monitor tool wrappers", () => {
     const waiting = await toolMap.get("LoopList")!.execute!("list-waiting", {});
     expect(waiting.content[0].text).toContain("Waiting on monitor #1");
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await vi.waitFor(() => {
+      expect(emittedEvents.some((event) => event.name === "loop:fire" && event.payload?.loopId === workflowId)).toBe(true);
+    }, { timeout: 2_000 });
     for (const handler of extensionHandlers.get("agent_end") ?? []) {
       await handler(null, createCtx());
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2136,6 +2136,38 @@ describe("monitor tool wrappers", () => {
     expect(loops.content[0].text).toBe("No loops configured. Use LoopCreate to set up a schedule.");
   }, 10000);
 
+  it("alerts the agent when a monitor times out without onDone", async () => {
+    const { pi, toolMap, extensionHandlers, sentMessages: sentCustomMessages } = createMockPi();
+
+    extension(pi as any);
+    await vi.advanceTimersByTimeAsync(6100);
+    vi.useRealTimers();
+
+    const ctx = {
+      ui: { setStatus: vi.fn(), setWidget: vi.fn() },
+      hasPendingMessages: () => false,
+      sessionManager: { getSessionId: () => "test-session" },
+    };
+    for (const handler of extensionHandlers.get("turn_start") ?? []) {
+      await handler(null, ctx);
+    }
+    for (const handler of extensionHandlers.get("agent_end") ?? []) {
+      await handler(null, ctx);
+    }
+
+    await toolMap.get("MonitorCreate")!.execute!("timeout-alert-monitor", {
+      command: "exec sleep 30",
+      timeout: 50,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(sentCustomMessages).toHaveLength(1);
+    expect((sentCustomMessages[0].message as { content: string }).content).toContain(
+      "Monitor #1 timed out",
+    );
+  }, 10000);
+
   it("does not deliver monitor completion wake if the completion loop is deleted", async () => {
     const { pi, toolMap, extensionHandlers, sentMessages: sentCustomMessages } = createMockPi();
 

--- a/test/loop-reducer.test.ts
+++ b/test/loop-reducer.test.ts
@@ -90,7 +90,8 @@ describe("loop reducer", () => {
           transitionSeq: 0,
           stateEnteredAt: 10,
           attemptsByState: { investigate: 1 },
-        },
+          stateFireCounts: {},
+        }
       },
     ], 2);
 
@@ -113,6 +114,48 @@ describe("loop reducer", () => {
     });
   });
 
+  it("reduces a completed terminal transition directly to a delete effect", () => {
+    const terminalWorkflow: WorkflowDefinition = {
+      version: 1,
+      initialState: "fix",
+      states: {
+        fix: { prompt: "Apply the fix.", on: { passing: "done" } },
+        done: { prompt: "Report completion.", terminal: "completed" },
+      },
+    };
+    const initial = makeState([{
+      id: "1",
+      prompt: "Fix the regression",
+      trigger: { type: "dynamic" },
+      status: "active",
+      recurring: true,
+      createdAt: 10,
+      updatedAt: 10,
+      expiresAt: 20,
+      fireCount: 0,
+      workflow: {
+        definition: terminalWorkflow,
+        currentState: "fix",
+        transitionSeq: 0,
+        stateEnteredAt: 10,
+        attemptsByState: { fix: 1 },
+        stateFireCounts: {},
+      },
+    }], 2);
+
+    const result = apply(initial, {
+      type: "LOOP_WORKFLOW_TERMINAL_TRANSITION",
+      at: 100,
+      source: "tool",
+      entityType: "loop",
+      entityId: "1",
+      payload: { id: "1", outcome: "passing", terminal: "completed" },
+    });
+
+    expect(result.state.loopsById).toEqual({});
+    expect(result.effects).toEqual([{ type: "DELETE_LOOP", entityType: "loop", entityId: "1", payload: { id: "1" } }]);
+  });
+
   it("records the task created for the active workflow state", () => {
     const initial = makeState([
       {
@@ -131,7 +174,8 @@ describe("loop reducer", () => {
           transitionSeq: 0,
           stateEnteredAt: 10,
           attemptsByState: { investigate: 1 },
-        },
+          stateFireCounts: {},
+        }
       },
     ], 2);
 

--- a/test/loop-tools.test.ts
+++ b/test/loop-tools.test.ts
@@ -702,7 +702,7 @@ describe("Workflow tools", () => {
     expect(h.store.get("1")?.workflow?.transitionSeq).toBe(1);
   });
 
-  it("closes an unbound destination task when the workflow advances concurrently", async () => {
+  it("closes an unbound destination task when the workflow completes concurrently", async () => {
     h.createWorkflowTask
       .mockResolvedValueOnce(undefined)
       .mockImplementationOnce(async () => {
@@ -715,8 +715,7 @@ describe("Workflow tools", () => {
 
     expect(out).toContain("changed while destination task #11 was created");
     expect(h.closeWorkflowTask).toHaveBeenCalledWith("11");
-    expect(h.store.get("1")?.workflow?.currentState).toBe("done");
-    expect(h.store.get("1")?.workflow?.activeTaskId).toBeUndefined();
+    expect(h.store.get("1")).toBeUndefined();
   });
 
   it("rejects an undeclared outcome without changing or re-arming the workflow", async () => {

--- a/test/loop-tools.test.ts
+++ b/test/loop-tools.test.ts
@@ -379,6 +379,32 @@ describe("Workflow tools", () => {
       done: { prompt: "Report completion.", terminal: "completed" },
     },
   });
+  const initialTaskDefinition = JSON.stringify({
+    version: 1,
+    initialState: "investigate",
+    states: {
+      investigate: {
+        prompt: "Find the cause.",
+        task: { subject: "Investigate regression", description: "Find the root cause." },
+        on: { found: "fix" },
+      },
+      fix: { prompt: "Fix it.", on: { passing: "done" } },
+      done: { prompt: "Report completion.", terminal: "completed" },
+    },
+  });
+  const destinationTaskDefinition = JSON.stringify({
+    version: 1,
+    initialState: "investigate",
+    states: {
+      investigate: { prompt: "Find the cause.", on: { found: "fix" } },
+      fix: {
+        prompt: "Fix it.",
+        task: { subject: "Fix regression", description: "Apply the fix." },
+        on: { passing: "done" },
+      },
+      done: { prompt: "Report completion.", terminal: "completed" },
+    },
+  });
 
   beforeEach(() => {
     h = setup();
@@ -438,6 +464,7 @@ describe("Workflow tools", () => {
       },
     });
 
+    h.createWorkflowTask.mockResolvedValueOnce("12");
     const out = await h.text("WorkflowCreate", { goal: "Process records", definition: scheduledDefinition });
 
     expect(out).toContain("State cadence: 0 7 * * * · state fires: 0/4 · controller fires: 0/4");
@@ -491,7 +518,7 @@ describe("Workflow tools", () => {
       return "12";
     });
 
-    const out = await h.text("WorkflowCreate", { goal: "Fix the regression", definition });
+    const out = await h.text("WorkflowCreate", { goal: "Fix the regression", definition: initialTaskDefinition });
 
     expect(out).toContain("changed while initial task #12 was created");
     expect(h.closeWorkflowTask).toHaveBeenCalledWith("12");
@@ -521,6 +548,51 @@ describe("Workflow tools", () => {
     expect(h.createWorkflowTask).not.toHaveBeenCalled();
   });
 
+  it("rolls back a task-bearing workflow when its initial task cannot be created", async () => {
+    const definitionWithTask = JSON.stringify({
+      version: 1,
+      initialState: "investigate",
+      states: {
+        investigate: {
+          prompt: "Find the cause.",
+          task: { subject: "Investigate regression", description: "Find the root cause." },
+          on: { found: "done" },
+        },
+        done: { prompt: "Report completion.", terminal: "completed" },
+      },
+    });
+
+    const out = await h.text("WorkflowCreate", { goal: "Fix the regression", definition: definitionWithTask });
+
+    expect(out).toContain("initial task could not be created");
+    expect(h.store.list()).toHaveLength(0);
+    expect(h.triggerSystem.add).not.toHaveBeenCalled();
+  });
+
+  it("does not advance into a task-bearing state when its task cannot be created", async () => {
+    const destinationTaskDefinition = JSON.stringify({
+      version: 1,
+      initialState: "investigate",
+      states: {
+        investigate: { prompt: "Find the cause.", on: { found: "fix" } },
+        fix: {
+          prompt: "Apply the fix.",
+          task: { subject: "Apply fix", description: "Implement and validate the fix." },
+          on: { passing: "done" },
+        },
+        done: { prompt: "Report completion.", terminal: "completed" },
+      },
+    });
+    await h.text("WorkflowCreate", { goal: "Fix the regression", definition: destinationTaskDefinition });
+    h.triggerSystem.add.mockClear();
+
+    const out = await h.text("WorkflowTransition", { id: "1", outcome: "found" });
+
+    expect(out).toContain("destination task could not be created");
+    expect(h.store.get("1")?.workflow?.currentState).toBe("investigate");
+    expect(h.triggerSystem.add).not.toHaveBeenCalled();
+  });
+
   it("creates and records a task declared by the active workflow state", async () => {
     h.createWorkflowTask.mockResolvedValueOnce("12");
     const definitionWithTask = JSON.stringify({
@@ -545,7 +617,7 @@ describe("Workflow tools", () => {
 
   it("closes an active state task before deleting its workflow", async () => {
     h.createWorkflowTask.mockResolvedValueOnce("12");
-    await h.text("WorkflowCreate", { goal: "Fix the regression", definition });
+    await h.text("WorkflowCreate", { goal: "Fix the regression", definition: initialTaskDefinition });
 
     expect(await h.text("LoopDelete", { id: "1", claimId: "claim-12" })).toBe("Loop #1 deleted");
     expect(h.closeWorkflowTask).toHaveBeenCalledWith("12", "claim-12");
@@ -555,7 +627,7 @@ describe("Workflow tools", () => {
   it("keeps a workflow when its active state task cannot be closed", async () => {
     h.createWorkflowTask.mockResolvedValueOnce("12");
     h.closeWorkflowTask.mockResolvedValueOnce(false);
-    await h.text("WorkflowCreate", { goal: "Fix the regression", definition });
+    await h.text("WorkflowCreate", { goal: "Fix the regression", definition: initialTaskDefinition });
 
     const out = await h.text("LoopDelete", { id: "1", claimId: "stale" });
 
@@ -720,13 +792,14 @@ describe("Workflow tools", () => {
     expect(out).toContain("Source task #10 could not be completed");
     expect(out).toContain("reclaim it and pass claimId");
     expect(h.store.get("1")).toEqual(before);
-    expect(h.createWorkflowTask).toHaveBeenCalledTimes(1);
+    expect(h.createWorkflowTask).toHaveBeenCalledTimes(2);
+    expect(h.closeWorkflowTask).toHaveBeenCalledWith("11");
     expect(h.triggerSystem.add).toHaveBeenCalledTimes(1);
   });
 
   it("rejects a stale transition instead of skipping a concurrently-entered state", async () => {
     h.createWorkflowTask.mockResolvedValueOnce("10");
-    await h.text("WorkflowCreate", { goal: "Fix the regression", definition });
+    await h.text("WorkflowCreate", { goal: "Fix the regression", definition: initialTaskDefinition });
     h.completeWorkflowTask.mockImplementationOnce(async () => {
       h.store.transitionWorkflow("1", { outcome: "found", evidence: "Concurrent transition." });
       return true;
@@ -739,20 +812,18 @@ describe("Workflow tools", () => {
     expect(h.store.get("1")?.workflow?.transitionSeq).toBe(1);
   });
 
-  it("closes an unbound destination task when the workflow completes concurrently", async () => {
-    h.createWorkflowTask
-      .mockResolvedValueOnce(undefined)
-      .mockImplementationOnce(async () => {
-        h.store.transitionWorkflow("1", { outcome: "passing", evidence: "Concurrent completion." });
-        return "11";
-      });
-    await h.text("WorkflowCreate", { goal: "Fix the regression", definition });
+  it("closes an unbound destination task when the workflow advances concurrently", async () => {
+    h.createWorkflowTask.mockImplementationOnce(async () => {
+      h.store.transitionWorkflow("1", { outcome: "found", evidence: "Concurrent transition." });
+      return "11";
+    });
+    await h.text("WorkflowCreate", { goal: "Fix the regression", definition: destinationTaskDefinition });
 
     const out = await h.text("WorkflowTransition", { id: "1", outcome: "found" });
 
-    expect(out).toContain("changed while destination task #11 was created");
+    expect(out).toContain("Workflow #1 changed; inspect LoopList and retry");
     expect(h.closeWorkflowTask).toHaveBeenCalledWith("11");
-    expect(h.store.get("1")).toBeUndefined();
+    expect(h.store.get("1")?.workflow?.currentState).toBe("fix");
   });
 
   it("rejects an undeclared outcome without changing or re-arming the workflow", async () => {

--- a/test/loop-tools.test.ts
+++ b/test/loop-tools.test.ts
@@ -15,6 +15,7 @@ function setup() {
   const completeWorkflowTask = vi.fn(async (_taskId: string, _claimId?: string) => true);
   const closeWorkflowTask = vi.fn(async (_taskId: string, _claimId?: string) => true);
   const maybeBootstrapTaskLoop = vi.fn(async () => false);
+  const isTaskSystemReady = vi.fn(() => true);
   registerLoopTools({
     pi,
     getStore: () => store as any,
@@ -23,7 +24,7 @@ function setup() {
     getMonitorManager: () => monitorManager as any,
     updateWidget: vi.fn(),
     maybeBootstrapTaskLoop,
-    isTaskSystemReady: () => true,
+    isTaskSystemReady,
     onDynamicLoopActivated,
     closeWorkflowTask,
   });
@@ -32,6 +33,7 @@ function setup() {
     getStore: () => store,
     getTriggerSystem: () => triggerSystem,
     updateWidget: vi.fn(),
+    isTaskSystemReady,
     onDynamicLoopActivated,
     createWorkflowTask,
     completeWorkflowTask,
@@ -39,7 +41,7 @@ function setup() {
   });
   const result = async (name: string, args: any) => await toolMap.get(name)!.execute!("t", args);
   const text = async (name: string, args: any) => (await result(name, args)).content[0].text as string;
-  return { store, triggerSystem, text, result, toolMap, maybeBootstrapTaskLoop, onDynamicLoopActivated, createWorkflowTask, completeWorkflowTask, closeWorkflowTask };
+  return { store, triggerSystem, text, result, toolMap, maybeBootstrapTaskLoop, isTaskSystemReady, onDynamicLoopActivated, createWorkflowTask, completeWorkflowTask, closeWorkflowTask };
 }
 
 describe("LoopCreate", () => {
@@ -103,6 +105,19 @@ describe("LoopCreate", () => {
       triggerType: "idle",
       taskBacklog: true,
     })).toContain('For a broad goal, use trigger "idle" with triggerType "idle" and omit taskBacklog.');
+    expect(h.store.list()).toHaveLength(0);
+  });
+
+  it("rejects autoTask on a task-backlog worker", async () => {
+    const out = await h.text("LoopCreate", {
+      trigger: "tasks:created",
+      prompt: "adopt unfinished tasks",
+      triggerType: "event",
+      taskBacklog: true,
+      autoTask: true,
+    });
+
+    expect(out).toContain("taskBacklog loops cannot enable autoTask");
     expect(h.store.list()).toHaveLength(0);
   });
 
@@ -482,6 +497,28 @@ describe("Workflow tools", () => {
     expect(h.closeWorkflowTask).toHaveBeenCalledWith("12");
     expect(h.triggerSystem.add).not.toHaveBeenCalled();
     expect(h.onDynamicLoopActivated).not.toHaveBeenCalled();
+  });
+
+  it("rejects a task-bearing workflow until task-provider detection settles", async () => {
+    h.isTaskSystemReady.mockReturnValue(false);
+    const definitionWithTask = JSON.stringify({
+      version: 1,
+      initialState: "investigate",
+      states: {
+        investigate: {
+          prompt: "Find the cause.",
+          task: { subject: "Investigate regression", description: "Find the root cause." },
+          on: { found: "done" },
+        },
+        done: { prompt: "Report completion.", terminal: "completed" },
+      },
+    });
+
+    const out = await h.text("WorkflowCreate", { goal: "Fix the regression", definition: definitionWithTask });
+
+    expect(out).toContain("Task system is still initializing");
+    expect(h.store.list()).toHaveLength(0);
+    expect(h.createWorkflowTask).not.toHaveBeenCalled();
   });
 
   it("creates and records a task declared by the active workflow state", async () => {

--- a/test/monitor-manager.test.ts
+++ b/test/monitor-manager.test.ts
@@ -390,7 +390,7 @@ describe("MonitorManager", () => {
     });
   });
 
-  it("notifies terminal callbacks when a monitor is manually stopped", async () => {
+  it("notifies workflow terminal callbacks only after a stopped process reaps", async () => {
     vi.useFakeTimers();
     const child = createMockChildProcess({ exitCode: null });
     manager = new MonitorManager(pi, createSequentialSpawn(child));
@@ -400,17 +400,24 @@ describe("MonitorManager", () => {
       expect(manager.onTerminal(entry.id, callback)).toBe(true);
 
       const stop = manager.stop(entry.id);
+      const lateCallback = vi.fn();
+      expect(manager.onTerminal(entry.id, lateCallback)).toBe(true);
+      expect(callback).not.toHaveBeenCalled();
+      expect(lateCallback).not.toHaveBeenCalled();
+      child.emit("close", 0);
+      await stop;
+
       expect(callback).toHaveBeenCalledWith(expect.objectContaining({
         id: entry.id,
         status: "stopped",
         stopReason: "manual",
       }));
-      await vi.advanceTimersByTimeAsync(5000);
-      await stop;
+      expect(lateCallback).toHaveBeenCalledWith(expect.objectContaining({
+        id: entry.id,
+        status: "stopped",
+        stopReason: "manual",
+      }));
     } finally {
-      const stop = manager.stop(entry.id);
-      await vi.advanceTimersByTimeAsync(5000);
-      await stop;
       vi.useRealTimers();
     }
   });

--- a/test/monitor-ondone-runtime.test.ts
+++ b/test/monitor-ondone-runtime.test.ts
@@ -48,6 +48,47 @@ function setup(manager: ReturnType<typeof mockManager>) {
 const flush = () => new Promise<void>((r) => setTimeout(r, 0));
 
 describe("monitor-ondone-runtime", () => {
+  it("delivers timeout alerts only after terminal reaping", async () => {
+    const timeoutLoop = {
+      ...doneLoop,
+      id: "7",
+      trigger: { type: "event", source: "monitor:timeout" },
+    } as LoopEntry;
+    const manager = mockManager({ onCompleteReturns: true, onTerminalReturns: true });
+    const onLoopFire = vi.fn();
+    const deleteLoop = vi.fn();
+    const runtime = createMonitorOnDoneRuntime({
+      monitorManager: manager as any,
+      getLoop: (id) => (id === timeoutLoop.id ? timeoutLoop : undefined),
+      deleteLoop,
+      onLoopFire,
+      completeWorkflowMonitorWait: vi.fn(),
+      rearmWorkflow: vi.fn(),
+      wakeWorkflow: vi.fn(),
+    });
+
+    runtime.register(timeoutLoop, "3");
+    expect(manager.onTerminal).toHaveBeenCalledTimes(1);
+    expect(manager.onComplete).not.toHaveBeenCalled();
+
+    manager.fireTerminal({
+      id: "3",
+      command: "fold scan",
+      timeout: 300000,
+      status: "stopped",
+      stopReason: "timeout",
+      startedAt: 0,
+      outputLines: 0,
+      outputBuffer: [],
+    } as MonitorEntry);
+    await flush();
+
+    expect(onLoopFire).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringContaining("Monitor #3 outcome: status=stopped"),
+    }));
+    expect(deleteLoop).toHaveBeenCalledWith(timeoutLoop.id);
+  });
+
   it("registers a completion callback on a running monitor and delivers once on completion", async () => {
     const manager = mockManager({ onCompleteReturns: true });
     const { runtime, onLoopFire, deleteLoop } = setup(manager);

--- a/test/monitor-tools.test.ts
+++ b/test/monitor-tools.test.ts
@@ -59,7 +59,10 @@ describe("MonitorCreate", () => {
     expect(out).toContain("Monitor #1 started");
     expect(out).toContain("monitor:output is rate-limited");
     expect(h.manager.create).toHaveBeenCalledWith("npm test", undefined, undefined);
-    expect(h.handleMonitorDoneLoop).not.toHaveBeenCalled();
+    expect(h.handleMonitorDoneLoop).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringContaining("Monitor #1 timed out"),
+      trigger: expect.objectContaining({ type: "event", source: "monitor:timeout" }),
+    }), "1");
     expect(h.toolMap.get("MonitorCreate")?.renderShell).toBe("self");
     expect(h.toolMap.get("MonitorCreate")?.renderResult).toBeTypeOf("function");
   });

--- a/test/notification-runtime.test.ts
+++ b/test/notification-runtime.test.ts
@@ -39,4 +39,32 @@ describe("notification runtime session boundary", () => {
 
     expect(sentMessages).toEqual([]);
   });
+
+  it("drops an old-session monitor start while delivering the current-session start", async () => {
+    const { pi, sentMessages } = createMockPi();
+    const runtime = createNotificationRuntime({
+      pi,
+      hasPendingTasks: vi.fn(async () => 0),
+      cleanDoneTasks: vi.fn(async () => {}),
+      getHasPendingMessages: () => false,
+    });
+
+    runtime.clear("session_shutdown");
+    await runtime.queueOrDeliverMonitorStarted({
+      monitorId: "old",
+      command: "npm test",
+      timestamp: 100,
+      sessionGeneration: 0,
+    });
+    await runtime.queueOrDeliverMonitorStarted({
+      monitorId: "current",
+      command: "npm run build",
+      timestamp: 101,
+      sessionGeneration: 1,
+    });
+    await runtime.flushPendingNotifications({ ignorePendingMessages: true });
+
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0].message.content).toContain("Monitor #current started");
+  });
 });

--- a/test/notification-runtime.test.ts
+++ b/test/notification-runtime.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { createNotificationRuntime } from "../src/runtime/notification-runtime.js";
+import { createMockPi } from "./helpers/mock-pi.js";
+
+describe("notification runtime session boundary", () => {
+  it("drops a wake whose task lookup completes after session shutdown", async () => {
+    const { pi, sentMessages } = createMockPi();
+    let resolvePending: ((pending: number) => void) | undefined;
+    let notifyPendingLookup: (() => void) | undefined;
+    const pendingLookupStarted = new Promise<void>((resolve) => {
+      notifyPendingLookup = resolve;
+    });
+    const pendingTasks = new Promise<number>((resolve) => {
+      resolvePending = resolve;
+    });
+    const runtime = createNotificationRuntime({
+      pi,
+      hasPendingTasks: vi.fn(() => {
+        notifyPendingLookup?.();
+        return pendingTasks;
+      }),
+      cleanDoneTasks: vi.fn(async () => {}),
+      getHasPendingMessages: () => false,
+    });
+
+    const queued = runtime.queueOrDeliverNotification({
+      loopId: "42",
+      prompt: "This wake belongs to the closed session",
+      trigger: { type: "cron", schedule: "*/5 * * * *" },
+      timestamp: 100,
+      autoTask: true,
+      recurring: false,
+    });
+    await pendingLookupStarted;
+
+    runtime.clear("session_shutdown");
+    resolvePending?.(1);
+    await queued;
+
+    expect(sentMessages).toEqual([]);
+  });
+});

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -176,6 +176,28 @@ describe("CronScheduler", () => {
     expect(store.get(entry.id)?.workflow?.stateFireCounts).toEqual({ collect: 1 });
   });
 
+  it("does not arm a legacy active terminal workflow after restart", () => {
+    const workflow = store.create({ type: "dynamic" }, "Finish", {
+      recurring: true,
+      workflow: {
+        version: 1,
+        initialState: "work",
+        states: {
+          work: { prompt: "Do the work.", on: { done: "done" } },
+          done: { prompt: "Report completion.", terminal: "completed" },
+        },
+      },
+    });
+    const stale = store.get(workflow.id)!;
+    stale.workflow!.currentState = "done";
+
+    scheduler.start();
+    scheduler.pump(Date.now());
+
+    expect(scheduler.nextFire(workflow.id)).toBeUndefined();
+    expect(fired).toEqual([]);
+  });
+
   it("suppresses workflow cadence while waiting on a monitor", () => {
     const entry = store.create({ type: "dynamic" }, "Validate", {
       recurring: true,

--- a/test/session-runtime.test.ts
+++ b/test/session-runtime.test.ts
@@ -37,8 +37,8 @@ function setup(overrides: Partial<SessionRuntimeOptions> = {}) {
     ...overrides,
   };
   registerSessionRuntimeHooks(options);
-  const drive = async (name: string) => {
-    for (const handler of extensionHandlers.get(name) ?? []) await handler(null, createCtx());
+  const drive = async (name: string, sessionId = "test-session") => {
+    for (const handler of extensionHandlers.get(name) ?? []) await handler(null, createCtx({ sessionId }));
   };
   return { scheduler, drive };
 }
@@ -142,6 +142,33 @@ describe("session-runtime heartbeat lifecycle", () => {
     await drive("session_shutdown");
 
     expect(clearIntervalSpy).toHaveBeenCalledWith(timer);
+  });
+
+  it("fully rebinds session-scoped runtime after shutdown", async () => {
+    const recreateSessionStore = vi.fn();
+    const setSessionId = vi.fn();
+    const triggerSystem = { start: vi.fn(), stop: vi.fn() };
+    const { drive } = setup({
+      getLoopScope: () => "session",
+      recreateSessionStore,
+      setSessionId,
+      getStore: () => ({
+        list: () => [{ id: "8", status: "active" }],
+        clearExpired: vi.fn(),
+        expireEventLoops: vi.fn(),
+      }) as any,
+      getTriggerSystem: () => triggerSystem,
+    });
+
+    await drive("session_start", "session-one");
+    await drive("session_shutdown");
+    await drive("session_start", "session-two");
+
+    expect(recreateSessionStore).toHaveBeenNthCalledWith(1, "session-one");
+    expect(recreateSessionStore).toHaveBeenNthCalledWith(2, "session-two");
+    expect(triggerSystem.stop).toHaveBeenCalledOnce();
+    expect(triggerSystem.start).toHaveBeenCalledTimes(2);
+    expect(setSessionId.mock.calls).toEqual([["session-one"], [undefined], ["session-two"]]);
   });
 
   it("clears workflow monitor waits before stopping monitors", async () => {

--- a/test/session-runtime.test.ts
+++ b/test/session-runtime.test.ts
@@ -4,11 +4,14 @@ import { createCtx, createMockPi } from "./helpers/mock-pi.js";
 
 function setup(overrides: Partial<SessionRuntimeOptions> = {}) {
   const { pi, extensionHandlers } = createMockPi();
+  let sessionGeneration = 0;
   const scheduler = { nextFire: vi.fn(() => undefined), pump: vi.fn() };
   const options: SessionRuntimeOptions = {
     pi,
     getLoopScope: () => "memory",
     getPiLoopEnv: () => undefined,
+    getSessionGeneration: () => sessionGeneration,
+    advanceSessionGeneration: () => ++sessionGeneration,
     recreateSessionStore: vi.fn(),
     clearAllLoops: vi.fn(),
     getStore: () => ({ list: () => [], clearExpired: vi.fn(), expireEventLoops: vi.fn() }) as any,
@@ -210,6 +213,43 @@ describe("session-runtime heartbeat lifecycle", () => {
     await drive("session_switch");
 
     expect(shutdownMonitors).toHaveBeenCalledOnce();
+  });
+
+  it("does not pump a newly rebound scheduler after shutdown during task lookup", async () => {
+    let resolvePending: (() => void) | undefined;
+    let notifyPendingLookup: (() => void) | undefined;
+    const pendingLookupStarted = new Promise<void>((resolve) => {
+      notifyPendingLookup = resolve;
+    });
+    const pendingTasks = new Promise<number>((resolve) => {
+      resolvePending = () => resolve(0);
+    });
+    const scheduler = { nextFire: vi.fn(() => Date.now()), pump: vi.fn() };
+    const { drive } = setup({
+      getStore: () => ({
+        list: () => [{
+          id: "8",
+          status: "active",
+          autoTask: true,
+          trigger: { type: "cron", schedule: "*/5 * * * *" },
+        }],
+        clearExpired: vi.fn(),
+        expireEventLoops: vi.fn(),
+      }) as any,
+      getScheduler: () => scheduler as any,
+      hasPendingTasks: vi.fn(() => {
+        notifyPendingLookup?.();
+        return pendingTasks;
+      }),
+    });
+
+    const turnStart = drive("turn_start");
+    await pendingLookupStarted;
+    await drive("session_shutdown");
+    resolvePending?.();
+    await turnStart;
+
+    expect(scheduler.pump).not.toHaveBeenCalled();
   });
 
   it("does not leak an unhandled rejection when a heartbeat pump throws", async () => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -2,6 +2,7 @@ import { rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CronScheduler } from "../src/scheduler.js";
 import { LoopStore } from "../src/store.js";
 import type { Trigger } from "../src/types.js";
 
@@ -137,6 +138,29 @@ describe("LoopStore (in-memory)", () => {
 
     expect(store.fire(workflow.id)).toBeUndefined();
     expect(store.get(workflow.id)?.fireCount).toBe(0);
+  });
+
+  it("counts only scheduler fires toward a workflow state's cadence budget", () => {
+    const workflow = store.create({ type: "dynamic" }, "Validate", {
+      recurring: true,
+      workflow: {
+        version: 1,
+        initialState: "validate",
+        states: {
+          validate: {
+            prompt: "Run validation.",
+            loop: { schedule: "*/5 * * * *", maxFires: 1 },
+            on: { passed: "done" },
+          },
+          done: { prompt: "Report completion.", terminal: "completed" },
+        },
+      },
+    });
+
+    store.fire(workflow.id, "monitor");
+    expect(store.get(workflow.id)?.workflow?.stateFireCounts).toEqual({});
+    store.fire(workflow.id, "scheduler");
+    expect(store.get(workflow.id)?.workflow?.stateFireCounts).toEqual({ validate: 1 });
   });
 
   it("updates loop prompt metadata", () => {
@@ -473,6 +497,36 @@ describe("LoopStore (file-backed)", () => {
 
     const restartedStore = new LoopStore(filePath);
     expect(restartedStore.get(workflow.id)).toBeUndefined();
+  });
+
+  it("does not arm a persisted legacy active terminal workflow after restart", () => {
+    const store1 = new LoopStore(filePath);
+    const workflow = store1.create({ type: "dynamic" }, "Finish", {
+      recurring: true,
+      workflow: {
+        version: 1,
+        initialState: "work",
+        states: {
+          work: { prompt: "Do the work.", on: { done: "done" } },
+          done: { prompt: "Report completion.", terminal: "completed" },
+        },
+      },
+    });
+    const activeTerminal = store1.get(workflow.id)!;
+    const snapshot = {
+      ...activeTerminal,
+      dynamic: { ...activeTerminal.dynamic, state: "done" },
+      workflow: { ...activeTerminal.workflow!, currentState: "done" },
+    };
+    writeFileSync(filePath, JSON.stringify({ nextId: 2, loops: [snapshot] }));
+
+    const restartedStore = new LoopStore(filePath);
+    const scheduler = new CronScheduler(restartedStore, () => {
+      throw new Error("terminal workflow must not fire");
+    });
+    scheduler.start();
+
+    expect(scheduler.nextFire(workflow.id)).toBeUndefined();
   });
 });
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -78,7 +78,7 @@ describe("LoopStore (in-memory)", () => {
     expect(entry!.status).toBe("active");
   });
 
-  it("does not resume a workflow paused in a terminal state", () => {
+  it("atomically pauses a workflow that reaches a paused terminal state", () => {
     store.create({ type: "dynamic" }, "Investigate", {
       recurring: true,
       workflow: {
@@ -91,11 +91,52 @@ describe("LoopStore (in-memory)", () => {
       },
     });
     const result = store.transitionWorkflow("1", { outcome: "blocked" });
-    expect(result.terminal).toBe("paused");
-    store.pause("1");
 
+    expect(result.terminal).toBe("paused");
     expect(store.resume("1")).toBeUndefined();
     expect(store.get("1")?.status).toBe("paused");
+  });
+
+  it("atomically removes a workflow that reaches a completed terminal state", () => {
+    const workflow = store.create({ type: "dynamic" }, "Finish", {
+      recurring: true,
+      workflow: {
+        version: 1,
+        initialState: "work",
+        states: {
+          work: { prompt: "Do the work.", on: { done: "done" } },
+          done: { prompt: "Report completion.", terminal: "completed" },
+        },
+      },
+    });
+
+    const result = store.transitionWorkflow(workflow.id, { outcome: "done" });
+
+    expect(result).toMatchObject({
+      applied: true,
+      terminal: "completed",
+      entry: { workflow: { currentState: "done" } },
+    });
+    expect(store.get(workflow.id)).toBeUndefined();
+  });
+
+  it("rejects a fire for a legacy active terminal workflow", () => {
+    const workflow = store.create({ type: "dynamic" }, "Finish", {
+      recurring: true,
+      workflow: {
+        version: 1,
+        initialState: "work",
+        states: {
+          work: { prompt: "Do the work.", on: { done: "done" } },
+          done: { prompt: "Report completion.", terminal: "completed" },
+        },
+      },
+    });
+    const stale = store.get(workflow.id)!;
+    stale.workflow!.currentState = "done";
+
+    expect(store.fire(workflow.id)).toBeUndefined();
+    expect(store.get(workflow.id)?.fireCount).toBe(0);
   });
 
   it("updates loop prompt metadata", () => {
@@ -412,6 +453,26 @@ describe("LoopStore (file-backed)", () => {
 
     const store2 = new LoopStore(filePath);
     expect(store2.list()).toHaveLength(0);
+  });
+
+  it("does not restore a completed workflow controller after restart", () => {
+    const store1 = new LoopStore(filePath);
+    const workflow = store1.create({ type: "dynamic" }, "Finish", {
+      recurring: true,
+      workflow: {
+        version: 1,
+        initialState: "work",
+        states: {
+          work: { prompt: "Do the work.", on: { done: "done" } },
+          done: { prompt: "Report completion.", terminal: "completed" },
+        },
+      },
+    });
+
+    expect(store1.transitionWorkflow(workflow.id, { outcome: "done" }).terminal).toBe("completed");
+
+    const restartedStore = new LoopStore(filePath);
+    expect(restartedStore.get(workflow.id)).toBeUndefined();
   });
 });
 

--- a/test/task-backlog-runtime.test.ts
+++ b/test/task-backlog-runtime.test.ts
@@ -195,6 +195,22 @@ describe("task backlog adoption", () => {
     expect(opts.adoptLoop).toHaveBeenNthCalledWith(2, loops[1]);
   });
 
+  it("reports work adopted before its session guard becomes stale", async () => {
+    let current = true;
+    const adoptLoop = vi.fn(() => {
+      current = false;
+    });
+    const { runtime, loops } = setup({
+      hasPendingTasks: vi.fn(async () => 2),
+      adoptLoop,
+    });
+    loops.push(makeLoop({ id: "1", taskBacklog: true }), makeLoop({ id: "2", taskBacklog: true }));
+
+    expect(await runtime.adoptTaskBacklogLoops(undefined, () => current)).toBe(1);
+    expect(adoptLoop).toHaveBeenCalledTimes(1);
+    expect(adoptLoop).toHaveBeenCalledWith(loops[0]);
+  });
+
   it("skips workers that already fired after the agent turn began", async () => {
     const { runtime, opts, loops } = setup({ hasPendingTasks: vi.fn(async () => 1) });
     loops.push(makeLoop({ taskBacklog: true, fireCount: 3 }));

--- a/test/task-backlog-runtime.test.ts
+++ b/test/task-backlog-runtime.test.ts
@@ -237,6 +237,24 @@ describe("explicit backlog policy", () => {
 });
 
 describe("cleanupTaskBacklogLoops", () => {
+  it("does not mutate backlog loops when its session guard becomes stale during lookup", async () => {
+    let resolvePending: ((pending: number) => void) | undefined;
+    const pending = new Promise<number>((resolve) => {
+      resolvePending = resolve;
+    });
+    let current = true;
+    const { runtime, opts, loops } = setup({ hasPendingTasks: vi.fn(() => pending) });
+    loops.push(makeLoop({ id: "1" }));
+
+    const cleanup = runtime.cleanupTaskBacklogLoops(() => current);
+    current = false;
+    resolvePending?.(0);
+
+    expect(await cleanup).toBe(0);
+    expect(loops).toHaveLength(1);
+    expect(opts.deleteLoop).not.toHaveBeenCalled();
+  });
+
   it("deletes backlog loops when zero tasks are pending and emits explicit signals", async () => {
     const { runtime, opts, loops } = setup({ hasPendingTasks: vi.fn(async () => 0) });
     loops.push(makeLoop({ id: "1" }));

--- a/test/task-provider-runtime.test.ts
+++ b/test/task-provider-runtime.test.ts
@@ -12,6 +12,7 @@ afterEach(() => {
 
 function setup(respondToTaskPing = false) {
   let sessionId = "session-a";
+  let sessionGeneration = 0;
   const mock = createMockPi({ respondToTaskPing });
   const evaluateTaskBacklog = vi.fn(async () => ({ created: false, cleaned: 0 }));
   const onReady = vi.fn(async () => {});
@@ -22,10 +23,18 @@ function setup(respondToTaskPing = false) {
     getSessionId: () => sessionId,
     evaluateTaskBacklog,
     onReady,
+    getSessionGeneration: () => sessionGeneration,
     updateWidget: vi.fn(),
     isStaleExtensionContextError: () => false,
   });
-  return { ...mock, runtime, evaluateTaskBacklog, onReady, setSessionId: (next: string) => { sessionId = next; } };
+  return {
+    ...mock,
+    runtime,
+    evaluateTaskBacklog,
+    onReady,
+    setSessionId: (next: string) => { sessionId = next; },
+    setSessionGeneration: (next: number) => { sessionGeneration = next; },
+  };
 }
 
 describe("task-provider-runtime", () => {
@@ -43,6 +52,15 @@ describe("task-provider-runtime", () => {
     expect(toolMap.has("TaskCreate")).toBe(true);
     expect(runtime.isReady()).toBe(true);
     expect(onReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("carries the detection generation into delayed readiness", async () => {
+    const { onReady, setSessionGeneration } = setup();
+
+    setSessionGeneration(1);
+    await vi.advanceTimersByTimeAsync(6_100);
+
+    expect(onReady).toHaveBeenCalledWith(0);
   });
 
   it("lets an external provider win without registering native tools", async () => {

--- a/test/tasks-command.test.ts
+++ b/test/tasks-command.test.ts
@@ -195,6 +195,35 @@ describe("registerTasksCommand", () => {
     expect(ui.notify).toHaveBeenCalledWith("Task #1 completed", "info");
   });
 
+  it("rejects terminal actions for workflow-owned tasks", async () => {
+    const h = setup();
+    h.taskStore.create("workflow attempt", "Use WorkflowTransition.", undefined, {
+      loopId: "9",
+      stateId: "fix",
+      transitionSeq: 1,
+    });
+
+    let taskVisits = 0;
+    const ui = {
+      select: vi.fn(async (title: string) => {
+        if (title === "Tasks") return taskVisits++ === 0 ? "* #1 [pending] workflow attempt" : "< Back";
+        if (title.startsWith("#1")) return "ok Complete";
+        return "< Back";
+      }),
+      input: vi.fn(),
+      notify: vi.fn(),
+    };
+
+    await h.command.handler!("", { ui } as any);
+
+    expect(h.taskStore.get("1")?.status).toBe("pending");
+    expect(h.emittedEvents.some((e) => e.name === "tasks:completed" && e.payload.taskId === "1")).toBe(false);
+    expect(ui.notify).toHaveBeenCalledWith(
+      "Task #1 unchanged: Task #1 is managed by workflow #9; transition or cancel the workflow instead.",
+      "warning",
+    );
+  });
+
   it("selecting a task and choosing Close without completing transitions it and emits tasks:closed", async () => {
     const h = setup();
     h.taskStore.create("subject", "desc");

--- a/test/workflow-task-integration.test.ts
+++ b/test/workflow-task-integration.test.ts
@@ -58,6 +58,39 @@ describe("linked workflow task integration", () => {
     return { ...harness, ctx, taskPath, loopPath };
   }
 
+  it("defers a task-bearing workflow until native task-provider detection settles", async () => {
+    const harness = createMockPi();
+    extension(harness.pi as any);
+    const sessionId = "workflow-detection";
+    const ctx = {
+      ui: { setStatus: vi.fn(), setWidget: vi.fn() },
+      hasPendingMessages: () => false,
+      sessionManager: { getSessionId: () => sessionId },
+    };
+    for (const handler of harness.extensionHandlers.get("turn_start") ?? []) await handler(null, ctx);
+
+    const deferred = await harness.toolMap.get("WorkflowCreate")!.execute!("early-create", {
+      goal: "Finish bounded workflow work",
+      definition: RETRY_WORKFLOW,
+    });
+    expect(deferred.content[0].text).toContain("Task system is still initializing");
+    expect(harness.toolMap.get("LoopList")!.execute).toBeDefined();
+    expect((await harness.toolMap.get("LoopList")!.execute!("early-list", {})).content[0].text).toBe("No loops configured. Use LoopCreate to set up a schedule.");
+
+    await vi.advanceTimersByTimeAsync(6_100);
+    const created = await harness.toolMap.get("WorkflowCreate")!.execute!("ready-create", {
+      goal: "Finish bounded workflow work",
+      definition: RETRY_WORKFLOW,
+    });
+    expect(created.content[0].text).toContain("Active task: #1");
+    const taskPath = resolveTaskStorePath({ loopScope: "session", cwd }, sessionId)!;
+    expect(new TaskStore(taskPath).get("1")?.workflow).toMatchObject({
+      loopId: "1",
+      stateId: "work",
+      transitionSeq: 0,
+    });
+  });
+
   it("self-loops through fresh linked attempts and terminates without orphan tasks", async () => {
     const h = await setup();
     const created = await h.toolMap.get("WorkflowCreate")!.execute!("create", {


### PR DESCRIPTION
## Summary
- fence stale session, notification, backlog, and provider-readiness work
- make terminal workflow transitions atomic and preserve cadence accounting
- enforce workflow task ownership and require linked task provisioning
- wait for monitor process reaping before terminal workflow wakes
- alert the agent when a monitor times out, even without `onDone`
- report partial backlog adoption accurately when a session guard becomes stale

## Validation
- `npm test` (679 passing)
- `npm run lint` (four pre-existing warnings)
- `npm run typecheck`
- `npm run build`
- `npm run test:package`

## Scope
Behavioral fixes only. Architectural refactors are intentionally excluded and remain tracked in the local workflow harness: execution records, wake outbox, scope leases, and monitor recovery.