### PR TITLE
feat(ui): unify Pi tool presentation

### DIFF
--- a/src/commands/loop-command.ts
+++ b/src/commands/loop-command.ts
@@ -6,6 +6,7 @@ import type {
 import { formatTrigger } from "../loop-format.js";
 import { isValidCronExpression, parseInterval } from "../loop-parse.js";
 import type { DynamicLoopState, LoopEntry, Trigger } from "../types.js";
+import { formatWorkflowInspection } from "../ui/workflow-presentation.js";
 import { isTerminalWorkflowRun } from "../workflow-reducer.js";
 
 interface LoopStoreLike {
@@ -170,10 +171,10 @@ export function registerLoopCommand(options: LoopCommandOptions): void {
         else if (entry.status === "paused" && !isTerminalWorkflowRun(entry.workflow)) actions.unshift("* Resume");
         actions.push("< Back");
 
-        const action = await ui.select(
-          `#${entry.id}: ${entry.prompt}\nTrigger: ${JSON.stringify(entry.trigger)}`,
-          actions,
-        );
+        const detail = entry.workflow
+          ? formatWorkflowInspection(entry)
+          : `#${entry.id}: ${entry.prompt}\nTrigger: ${JSON.stringify(entry.trigger)}`;
+        const action = await ui.select(detail, actions);
 
         if (action === "x Delete") {
           getTriggerSystem().remove(entry.id);

--- a/src/tools/loop-tools.ts
+++ b/src/tools/loop-tools.ts
@@ -413,11 +413,17 @@ Use this before creating new loops to avoid duplicates, or to find IDs for LoopD
         }
       }
 
+      const workflowCount = loops.filter((entry) => entry.workflow !== undefined).length;
+      const ordinaryCount = loops.length - workflowCount;
+      const kinds = [
+        ordinaryCount > 0 ? `${ordinaryCount} loop${ordinaryCount === 1 ? "" : "s"}` : undefined,
+        workflowCount > 0 ? `${workflowCount} workflow${workflowCount === 1 ? "" : "s"}` : undefined,
+      ].filter((label): label is string => label !== undefined);
       return Promise.resolve(textResult(lines.join("\n"), {
         kind: "loop",
         action: "list",
         tone: "info",
-        summary: `${loops.length} loop${loops.length === 1 ? "" : "s"} · ${loops.filter((entry) => entry.status === "active").length} active`,
+        summary: `${kinds.join(" · ")} · ${loops.filter((entry) => entry.status === "active").length} active`,
         expanded: displayRows(lines),
       }));
     },

--- a/src/tools/monitor-tools.ts
+++ b/src/tools/monitor-tools.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import type { LoopEntry, MonitorEntry, MonitorProgress, Trigger, WorkflowMonitorWait } from "../types.js";
-import { hideToolTranscript } from "../ui/tool-renderer.js";
+import { renderToolCall, renderToolResult, toolArg } from "../ui/tool-renderer.js";
 import { displayRows, textResult } from "./tool-result.js";
 
 interface MonitorManagerLike {
@@ -67,9 +67,8 @@ export function registerMonitorTools(options: MonitorToolsOptions): void {
   } = options;
 
   pi.registerTool({ name: "MonitorCreate", label: "MonitorCreate",
-  renderShell: "self",
-  renderCall: hideToolTranscript,
-  renderResult: hideToolTranscript, description: `Run a long command in the background while the agent continues. Use MonitorList for status/output; do not poll with shell sleep loops.\n\nTimed monitors always wake the agent if they time out. Pass onDone to create a completion wake for success, failure, or timeout. Pass workflowId to pause its workflow until a terminal result. Commands may emit JSONL progress as {"progress":{...}}; otherwise use MonitorUpdate.`, promptGuidelines: ["Use MonitorCreate for builds, CI checks, experiments, and other commands that need not block the turn.", "Use onDone when the agent must resume automatically after success or failure; timed monitors already alert on timeout.", "For an active workflow, use workflowId instead of onDone and await its completion wake."], parameters: Type.Object({
+  renderCall: renderToolCall("Monitor", (args) => `start · ${String(toolArg(args, "description") ?? toolArg(args, "command") ?? "background command").slice(0, 56)}`),
+  renderResult: renderToolResult, description: `Run a long command in the background while the agent continues. Use MonitorList for status/output; do not poll with shell sleep loops.\n\nTimed monitors always wake the agent if they time out. Pass onDone to create a completion wake for success, failure, or timeout. Pass workflowId to pause its workflow until a terminal result. Commands may emit JSONL progress as {"progress":{...}}; otherwise use MonitorUpdate.`, promptGuidelines: ["Use MonitorCreate for builds, CI checks, experiments, and other commands that need not block the turn.", "Use onDone when the agent must resume automatically after success or failure; timed monitors already alert on timeout.", "For an active workflow, use workflowId instead of onDone and await its completion wake."], parameters: Type.Object({
     command: Type.String({ description: "Shell command to run in background" }),
     description: Type.Optional(Type.String({ description: "Human-readable description" })),
     timeout: Type.Optional(Type.Number({ description: "Auto-stop after N ms (default: 300000, 0 = no timeout)", default: 300000 })),
@@ -163,9 +162,8 @@ export function registerMonitorTools(options: MonitorToolsOptions): void {
   pi.registerTool({
     name: "MonitorList",
     label: "MonitorList",
-    renderShell: "self",
-    renderCall: hideToolTranscript,
-    renderResult: hideToolTranscript,
+    renderCall: renderToolCall("Monitor", () => "status"),
+    renderResult: renderToolResult,
     description: "List all monitors with their status, command, exit code, output line count, and last 5 lines of buffered output.",
     parameters: Type.Object({}),
     execute() {
@@ -211,9 +209,8 @@ export function registerMonitorTools(options: MonitorToolsOptions): void {
   pi.registerTool({
     name: "MonitorUpdate",
     label: "MonitorUpdate",
-    renderShell: "self",
-    renderCall: hideToolTranscript,
-    renderResult: hideToolTranscript,
+    renderCall: renderToolCall("Monitor", (args) => `update · #${String(toolArg(args, "monitorId") ?? "?")}`),
+    renderResult: renderToolResult,
     description: "Set trustworthy structured progress for a running monitor that cannot emit JSONL. Pass monitorId and current/total or message. Do not use it for raw output or polling; use MonitorList.",
     parameters: Type.Object({
       monitorId: Type.String({ description: "Monitor ID to update" }),
@@ -242,9 +239,8 @@ export function registerMonitorTools(options: MonitorToolsOptions): void {
   pi.registerTool({
     name: "MonitorStop",
     label: "MonitorStop",
-    renderShell: "self",
-    renderCall: hideToolTranscript,
-    renderResult: hideToolTranscript,
+    renderCall: renderToolCall("Monitor", (args) => `stop · #${String(toolArg(args, "monitorId") ?? "?")}`),
+    renderResult: renderToolResult,
     description: `Stop a running monitor. Sends SIGTERM, waits 5s, then SIGKILL.
 
 Use MonitorList to find the monitor ID, then stop it with this tool.`,

--- a/src/tools/tool-result.ts
+++ b/src/tools/tool-result.ts
@@ -1,5 +1,7 @@
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "@earendil-works/pi-coding-agent";
+
 /** Plain-text tool result in the shape pi's registerTool expects. */
-export type ToolDisplayKind = "loop" | "workflow" | "task" | "monitor";
+type ToolDisplayKind = "loop" | "workflow" | "task" | "monitor";
 export type ToolDisplayTone = "success" | "warning" | "error" | "info";
 
 export interface ToolDisplayDetails {
@@ -8,13 +10,24 @@ export interface ToolDisplayDetails {
   tone: ToolDisplayTone;
   summary: string;
   expanded?: string[];
+  expandable?: boolean;
 }
 
 export function displayRows(rows: string[], limit = 8): string[] {
-  if (rows.length <= limit) return rows;
-  return [...rows.slice(0, limit), `… ${rows.length - limit} more`];
+  const lines = rows.flatMap((row) => row.split("\n"));
+  if (lines.length <= limit) return lines;
+  return [...lines.slice(0, limit), `… ${lines.length - limit} more`];
+}
+
+function truncateToolContent(content: string): string {
+  const result = truncateHead(content, { maxLines: DEFAULT_MAX_LINES, maxBytes: DEFAULT_MAX_BYTES });
+  if (!result.truncated) return content;
+  return `${result.content}\n\n[Output truncated: ${result.outputLines} of ${result.totalLines} lines (${formatSize(result.outputBytes)} of ${formatSize(result.totalBytes)}). Narrow the request to inspect the omitted content.]`;
 }
 
 export function textResult(msg: string, details?: ToolDisplayDetails) {
-  return { content: [{ type: "text" as const, text: msg }], details };
+  const display = details
+    ? { ...details, expandable: details.expandable ?? Boolean(details.expanded?.length) }
+    : undefined;
+  return { content: [{ type: "text" as const, text: truncateToolContent(msg) }], details: display };
 }

--- a/src/tools/tool-result.ts
+++ b/src/tools/tool-result.ts
@@ -1,3 +1,7 @@
+import { randomUUID } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "@earendil-works/pi-coding-agent";
 
 /** Plain-text tool result in the shape pi's registerTool expects. */
@@ -22,7 +26,9 @@ export function displayRows(rows: string[], limit = 8): string[] {
 function truncateToolContent(content: string): string {
   const result = truncateHead(content, { maxLines: DEFAULT_MAX_LINES, maxBytes: DEFAULT_MAX_BYTES });
   if (!result.truncated) return content;
-  return `${result.content}\n\n[Output truncated: ${result.outputLines} of ${result.totalLines} lines (${formatSize(result.outputBytes)} of ${formatSize(result.totalBytes)}). Narrow the request to inspect the omitted content.]`;
+  const fullOutputPath = join(tmpdir(), `pi-loop-tool-${randomUUID()}.log`);
+  writeFileSync(fullOutputPath, content, { encoding: "utf8", mode: 0o600 });
+  return `${result.content}\n\n[Output truncated: ${result.outputLines} of ${result.totalLines} lines (${formatSize(result.outputBytes)} of ${formatSize(result.totalBytes)}). Full output: ${fullOutputPath}]`;
 }
 
 export function textResult(msg: string, details?: ToolDisplayDetails) {

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -3,6 +3,7 @@ import { Type } from "typebox";
 import { formatLastTransitionLines } from "../loop-format.js";
 import type { LoopEntry, Trigger, WorkflowDefinition, WorkflowRevisionChange, WorkflowRevisionFailure, WorkflowRuntimeActor } from "../types.js";
 import { renderToolCall, renderToolResult, toolArg } from "../ui/tool-renderer.js";
+import { workflowAttemptLabel, workflowDisplayDetails } from "../ui/workflow-presentation.js";
 import { validateWorkflowDefinition } from "../workflow-definition.js";
 import { getActiveWorkflowStateLoop, getWorkflowOutcomeAvailability, type WorkflowTransitionFailure } from "../workflow-reducer.js";
 import type { WorkflowRevisionSummary } from "../workflow-revision.js";
@@ -175,10 +176,20 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
     }),
     async execute(_toolCallId, params) {
       const parsed = parseWorkflowDefinition(params.definition);
-      if (!parsed.definition) return textResult(formatWorkflowDefinitionError(parsed.error));
+      if (!parsed.definition) {
+        const message = formatWorkflowDefinitionError(parsed.error);
+        return textResult(message, {
+          kind: "workflow", action: "create", tone: "error", summary: "Workflow was not created", expanded: [message],
+        });
+      }
       const actor = getActor();
       const initial = parsed.definition.states[parsed.definition.initialState];
-      if (initial?.task && !actor) return textResult("Workflow creation requires an active session runtime; retry after turn_start.");
+      if (initial?.task && !actor) {
+        const message = "Workflow creation requires an active session runtime; retry after turn_start.";
+        return textResult(message, {
+          kind: "workflow", action: "create", tone: "error", summary: "Workflow runtime unavailable", expanded: [message],
+        });
+      }
       const entry = getStore().create({ type: "dynamic" }, params.goal, {
         recurring: true,
         maxFires: params.maxFires ?? workflowDefaultMaxFires(parsed.definition),
@@ -189,7 +200,19 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
       getTriggerSystem().add(entry);
       updateWidget();
       if (!entry.workflow || !getActiveWorkflowStateLoop(entry.workflow) || stateLoopStartsImmediately(entry)) onDynamicLoopActivated?.(entry);
-      return textResult(`${formatWorkflowSummary(entry, `Workflow #${entry.id} created — ${entry.status}`)}\nWake: ${entry.workflow && getActiveWorkflowStateLoop(entry.workflow) ? "scheduled from the active state cadence." : "the state instruction will be delivered when the agent becomes idle."}`);
+      const wake = entry.workflow && getActiveWorkflowStateLoop(entry.workflow)
+        ? "scheduled from the active state cadence."
+        : "the state instruction will be delivered when the agent becomes idle.";
+      return textResult(
+        `${formatWorkflowSummary(entry, `Workflow #${entry.id} created — ${entry.status}`)}\nWake: ${wake}`,
+        workflowDisplayDetails({
+          entry,
+          action: "create",
+          tone: "success",
+          summary: `Workflow #${entry.id} active · ${entry.workflow?.currentState ?? "unknown"} · attempt ${workflowAttemptLabel(entry)}`,
+          extra: [`Wake: ${wake}`],
+        }),
+      );
     },
   });
 
@@ -209,11 +232,29 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
     }),
     async execute(_toolCallId, params) {
       const actor = getActor();
-      if (!actor) return textResult("Workflow claim requires an active session runtime; retry after turn_start.");
+      if (!actor) {
+        const message = "Workflow claim requires an active session runtime; retry after turn_start.";
+        return textResult(message, {
+          kind: "workflow", action: "claim", tone: "error", summary: `Workflow #${params.id} claim rejected`, expanded: [message],
+        });
+      }
       const result = getStore().claimWorkflowExecution(params.id, actor, params.leaseSeconds);
-      if (!result.claimed || !result.entry) return textResult(`Workflow #${params.id} was not claimed\nReason: ${result.error ?? "unknown error"}`);
+      if (!result.claimed || !result.entry) {
+        const reason = result.error ?? "unknown error";
+        return textResult(`Workflow #${params.id} was not claimed\nReason: ${reason}`, {
+          kind: "workflow", action: "claim", tone: "error", summary: `Workflow #${params.id} claim rejected`, expanded: [reason],
+        });
+      }
       const execution = result.entry.workflow?.activeExecution;
-      return textResult(`Workflow #${params.id} lease active until ${execution?.lease ? new Date(execution.lease.expiresAt).toISOString() : "unknown"}\n${formatWorkflowSummary(result.entry, `Workflow #${params.id} — ${result.entry.status}`)}`);
+      return textResult(
+        `Workflow #${params.id} lease active until ${execution?.lease ? new Date(execution.lease.expiresAt).toISOString() : "unknown"}\n${formatWorkflowSummary(result.entry, `Workflow #${params.id} — ${result.entry.status}`)}`,
+        workflowDisplayDetails({
+          entry: result.entry,
+          action: "claim",
+          tone: "success",
+          summary: `Workflow #${params.id} lease active · ${result.entry.workflow?.currentState ?? "unknown"}`,
+        }),
+      );
     },
   });
 
@@ -248,9 +289,19 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
       }, getActor());
       if (!result.applied || !result.entry || !result.summary) {
         const failure = result.failure;
-        return textResult(
-          `Workflow #${params.id} was not revised\nCode: ${failure?.code ?? "unknown"}\nReason: ${result.error ?? "unknown revision error"}\nNext: ${revisionRecovery(failure?.code)}`,
-        );
+        const reason = result.error ?? "unknown revision error";
+        const next = revisionRecovery(failure?.code);
+        const message = `Workflow #${params.id} was not revised\nCode: ${failure?.code ?? "unknown"}\nReason: ${reason}\nNext: ${next}`;
+        const current = getStore().get(params.id);
+        return textResult(message, current?.workflow
+          ? workflowDisplayDetails({
+              entry: current,
+              action: "revise",
+              tone: "error",
+              summary: `Workflow #${params.id} revision rejected`,
+              extra: [`Reason: ${reason}`, `Next: ${next}`],
+            })
+          : { kind: "workflow", action: "revise", tone: "error", summary: `Workflow #${params.id} revision rejected`, expanded: [`Reason: ${reason}`, `Next: ${next}`] });
       }
       updateWidget();
       const summary = result.summary;
@@ -269,7 +320,16 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
       const execution = result.entry.workflow?.activeExecution;
       lines.push(`Current execution preserved: ${result.entry.workflow?.currentState}${execution ? ` (${execution.id})` : ""}`);
       lines.push("Next: complete the active work and transition through the revised outcome.");
-      return textResult(lines.join("\n"));
+      return textResult(
+        lines.join("\n"),
+        workflowDisplayDetails({
+          entry: result.entry,
+          action: "revise",
+          tone: "success",
+          summary: `Workflow #${params.id} revised · r${params.expectedRevision} → r${result.entry.workflow?.definitionRevision ?? "?"}`,
+          extra: lines.slice(1),
+        }),
+      );
     },
   });
 
@@ -302,19 +362,58 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
       if (!result.applied || !result.entry) {
         const entry = store.get(params.id);
         const error = result.error ?? "unknown transition error";
-        return textResult(entry?.workflow
+        const message = entry?.workflow
           ? `Workflow #${params.id} did not transition\nReason: ${error}\n${formatWorkflowSummary(entry, `Workflow #${params.id} remains — ${entry.status}`, result.failure)}`
-          : `Workflow #${params.id} did not transition\nReason: ${error}`);
+          : `Workflow #${params.id} did not transition\nReason: ${error}`;
+        return textResult(message, entry?.workflow
+          ? workflowDisplayDetails({
+              entry,
+              action: "transition",
+              tone: "error",
+              summary: `Workflow #${params.id} transition rejected`,
+              extra: [`Reason: ${error}`],
+            })
+          : { kind: "workflow", action: "transition", tone: "error", summary: `Workflow #${params.id} transition rejected`, expanded: [`Reason: ${error}`] });
       }
       const entry = result.entry;
       getTriggerSystem().remove(entry.id);
       updateWidget();
-      if (result.terminal === "completed") return textResult(`Workflow #${entry.id} completed and deleted\nFinal transition: ${entry.workflow?.lastTransition?.from ?? "?"} → ${entry.workflow?.currentState ?? "?"}`);
-      if (result.terminal === "paused") return textResult(`Workflow #${entry.id} paused\nFinal state: ${entry.workflow?.currentState ?? "?"}`);
+      if (result.terminal === "completed") {
+        const transition = `${entry.workflow?.lastTransition?.from ?? "?"} → ${entry.workflow?.currentState ?? "?"}`;
+        return textResult(
+          `Workflow #${entry.id} completed and deleted\nFinal transition: ${transition}`,
+          workflowDisplayDetails({
+            entry,
+            action: "transition",
+            tone: "success",
+            summary: `Workflow #${entry.id} completed · ${transition}`,
+          }),
+        );
+      }
+      if (result.terminal === "paused") {
+        return textResult(
+          `Workflow #${entry.id} paused\nFinal state: ${entry.workflow?.currentState ?? "?"}`,
+          workflowDisplayDetails({
+            entry,
+            action: "transition",
+            tone: "warning",
+            summary: `Workflow #${entry.id} paused · ${entry.workflow?.currentState ?? "unknown"}`,
+          }),
+        );
+      }
       const resumed = entry.status === "paused" ? store.resume(entry.id) ?? entry : entry;
       getTriggerSystem().add(resumed);
       if (stateLoopStartsImmediately(resumed)) onDynamicLoopActivated?.(resumed);
-      return textResult(`Workflow #${resumed.id} advanced: ${resumed.workflow?.lastTransition?.from ?? "?"} → ${resumed.workflow?.currentState ?? "?"}\n${formatWorkflowSummary(resumed, `Workflow #${resumed.id} — ${resumed.status}`)}`);
+      const transition = `${resumed.workflow?.lastTransition?.from ?? "?"} → ${resumed.workflow?.currentState ?? "?"}`;
+      return textResult(
+        `Workflow #${resumed.id} advanced: ${transition}\n${formatWorkflowSummary(resumed, `Workflow #${resumed.id} — ${resumed.status}`)}`,
+        workflowDisplayDetails({
+          entry: resumed,
+          action: "transition",
+          tone: "success",
+          summary: `Workflow #${resumed.id} advanced · ${transition}`,
+        }),
+      );
     },
   });
 }

--- a/src/ui/tool-renderer.ts
+++ b/src/ui/tool-renderer.ts
@@ -1,4 +1,4 @@
-import type { AgentToolResult, Theme, ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
+import { type AgentToolResult, keyHint, type Theme, type ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
 import { Container, Text } from "@earendil-works/pi-tui";
 import type { ToolDisplayDetails } from "../tools/tool-result.js";
 
@@ -20,28 +20,39 @@ export function hideToolTranscript() {
   return new Container();
 }
 
+function toneAppearance(tone: ToolDisplayDetails["tone"]): { color: "success" | "warning" | "error" | "muted"; icon: string } {
+  switch (tone) {
+    case "success": return { color: "success", icon: "✓" };
+    case "warning": return { color: "warning", icon: "!" };
+    case "error": return { color: "error", icon: "✕" };
+    default: return { color: "muted", icon: "•" };
+  }
+}
+
 export function renderToolResult(
   result: AgentToolResult<unknown>,
   { expanded, isPartial }: ToolRenderResultOptions,
   theme: Theme,
+  context?: { isError?: boolean },
 ) {
-  if (isPartial) return new Text(theme.fg("warning", "Working…"), 0, 0);
-
   const details = result.details as ToolDisplayDetails | undefined;
-  if (!details) {
-    const content = result.content[0];
-    return new Text(content?.type === "text" ? content.text : "No result", 0, 0);
+  if (isPartial) {
+    const progress = details?.summary ? `… ${details.summary}` : "Working…";
+    return new Text(theme.fg("warning", progress), 0, 0);
   }
 
-  const color = details.tone === "success"
-    ? "success"
-    : details.tone === "warning"
-      ? "warning"
-      : details.tone === "error"
-        ? "error"
-        : "muted";
-  const icon = details.tone === "success" ? "✓" : details.tone === "error" ? "✕" : details.tone === "warning" ? "!" : "•";
+  if (!details) {
+    const content = result.content[0];
+    const output = content?.type === "text" ? content.text : "No result";
+    return new Text(context?.isError ? theme.fg("error", `✕ ${output}`) : output, 0, 0);
+  }
+
+  const tone = context?.isError ? "error" : details.tone;
+  const { color, icon } = toneAppearance(tone);
   let text = theme.fg(color, `${icon} ${details.summary}`);
+  if (!expanded && details.expandable) {
+    text += theme.fg("dim", ` · ${keyHint("app.tools.expand", "to expand")}`);
+  }
   if (expanded && details.expanded?.length) {
     for (const line of details.expanded) text += `\n${theme.fg("dim", line)}`;
   }

--- a/src/ui/tool-renderer.ts
+++ b/src/ui/tool-renderer.ts
@@ -1,14 +1,41 @@
 import { type AgentToolResult, keyHint, type Theme, type ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
-import { Container, Text } from "@earendil-works/pi-tui";
+import { Container, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import type { ToolDisplayDetails } from "../tools/tool-result.js";
 
 type ToolCallArgs = object;
+const MAX_EXPANDED_VISUAL_LINES = 12;
+
+function singleLine(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+class BoundedToolText extends Text {
+  constructor(
+    private readonly summary: string,
+    private readonly expandedText?: string,
+    private readonly overflowTemplate?: string,
+  ) {
+    super("", 0, 0);
+  }
+
+  override render(width: number): string[] {
+    const lines = [truncateToWidth(this.summary, width)];
+    if (!this.expandedText) return lines;
+    const visualLines = new Text(this.expandedText, 0, 0).render(width);
+    lines.push(...visualLines.slice(0, MAX_EXPANDED_VISUAL_LINES));
+    if (visualLines.length > MAX_EXPANDED_VISUAL_LINES) {
+      const overflow = `… ${visualLines.length - MAX_EXPANDED_VISUAL_LINES} more visual lines`;
+      lines.push(truncateToWidth(this.overflowTemplate?.replace("__OVERFLOW__", overflow) ?? overflow, width));
+    }
+    return lines;
+  }
+}
 
 export function renderToolCall(label: string, summarize: (args: ToolCallArgs) => string) {
   return (args: ToolCallArgs, theme: Theme) => {
-    const summary = summarize(args);
+    const summary = singleLine(summarize(args));
     const text = theme.fg("toolTitle", theme.bold(`${label} `)) + theme.fg("muted", summary);
-    return new Text(text, 0, 0);
+    return new BoundedToolText(text);
   };
 }
 
@@ -37,7 +64,7 @@ export function renderToolResult(
 ) {
   const details = result.details as ToolDisplayDetails | undefined;
   if (isPartial) {
-    const progress = details?.summary ? `… ${details.summary}` : "Working…";
+    const progress = details?.summary ? `… ${singleLine(details.summary)}` : "Working…";
     return new Text(theme.fg("warning", progress), 0, 0);
   }
 
@@ -49,12 +76,12 @@ export function renderToolResult(
 
   const tone = context?.isError ? "error" : details.tone;
   const { color, icon } = toneAppearance(tone);
-  let text = theme.fg(color, `${icon} ${details.summary}`);
+  let summary = theme.fg(color, `${icon} ${singleLine(details.summary)}`);
   if (!expanded && details.expandable) {
-    text += theme.fg("dim", ` · ${keyHint("app.tools.expand", "to expand")}`);
+    summary += theme.fg("dim", ` · ${keyHint("app.tools.expand", "to expand")}`);
   }
-  if (expanded && details.expanded?.length) {
-    for (const line of details.expanded) text += `\n${theme.fg("dim", line)}`;
-  }
-  return new Text(text, 0, 0);
+  const expandedText = expanded && details.expanded?.length
+    ? details.expanded.map((line) => theme.fg("dim", line)).join("\n")
+    : undefined;
+  return new BoundedToolText(summary, expandedText, theme.fg("dim", "__OVERFLOW__"));
 }

--- a/src/ui/widget.ts
+++ b/src/ui/widget.ts
@@ -2,6 +2,7 @@ import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import type { MonitorManager } from "../monitor-manager.js";
 import type { LoopStore } from "../store.js";
 import type { LoopEntry } from "../types.js";
+import { workflowAttemptLabel, workflowLeaseLabel } from "./workflow-presentation.js";
 
 interface TaskSummary {
   count: number;
@@ -36,6 +37,8 @@ export class LoopWidget {
 
   private computeStatus(): string | undefined {
     const loops = this.store.list().filter(isStatusVisibleLoop);
+    const workflows = loops.filter((loop) => loop.workflow !== undefined);
+    const ordinaryLoops = loops.filter((loop) => loop.workflow === undefined);
     const monitors = this.monitorManager.list().filter((monitor) => monitor.status === "running");
     const taskSummary = this.taskSummaryProvider?.() ?? { count: 0 };
 
@@ -44,7 +47,8 @@ export class LoopWidget {
     }
 
     const parts: string[] = [];
-    if (loops.length > 0) parts.push(`↻ ${formatCount(loops.length, "loop")}`);
+    if (ordinaryLoops.length > 0) parts.push(`↻ ${formatCount(ordinaryLoops.length, "loop")}`);
+    if (workflows.length > 0) parts.push(`◆ ${formatCount(workflows.length, "workflow")}`);
     if (monitors.length > 0) parts.push(`▶ ${formatCount(monitors.length, "monitor")}`);
     if (taskSummary.count > 0) parts.push(`□ ${formatCount(taskSummary.count, "task")}`);
 
@@ -53,6 +57,10 @@ export class LoopWidget {
     if (monitors.length === 1 && monitor) {
       const activity = formatMonitorActivity(monitor);
       if (activity) line += ` | ${activity}`;
+    }
+    const workflow = workflows.length === 1 ? workflows[0] : undefined;
+    if (workflow?.workflow) {
+      line += ` | #${workflow.id} ${workflow.workflow.currentState} · attempt ${workflowAttemptLabel(workflow)} · ${workflowLeaseLabel(workflow)}`;
     }
     if (taskSummary.focusText) line += ` | ${taskSummary.focusText}`;
     return line;

--- a/src/ui/workflow-presentation.ts
+++ b/src/ui/workflow-presentation.ts
@@ -11,7 +11,7 @@ export function workflowAttemptLabel(entry: LoopEntry): string {
   return state?.maxAttempts ? `${attempt}/${state.maxAttempts}` : String(attempt);
 }
 
-function workflowLease(entry: LoopEntry): string {
+export function workflowLeaseLabel(entry: LoopEntry): string {
   const workflow = entry.workflow;
   if (!workflow) return "unavailable";
   const execution = workflow.activeExecution;
@@ -46,7 +46,7 @@ export function workflowDisplayDetails({
     `Attempt: ${workflowAttemptLabel(entry)}`,
     state?.prompt ? `Instruction: ${state.prompt}` : undefined,
     workflow.activeExecution ? `Work: ${workflow.activeExecution.subject} (${workflow.activeExecution.id})` : undefined,
-    `Lease: ${workflowLease(entry)}`,
+    `Lease: ${workflowLeaseLabel(entry)}`,
     availability.available.length > 0 ? `Outcomes: ${availability.available.join(", ")}` : undefined,
     availability.unavailable.length > 0 ? `Unavailable: ${availability.unavailable.map((item) => item.outcome).join(", ")}` : undefined,
     workflow.waitingMonitor ? `Waiting: monitor #${workflow.waitingMonitor.monitorId}` : undefined,
@@ -65,7 +65,7 @@ export function formatWorkflowInspection(entry: LoopEntry): string {
     `#${entry.id}: ${entry.prompt}`,
     `State: ${workflow.currentState} · attempt ${workflowAttemptLabel(entry)}`,
     `Revision: ${workflow.definitionRevision} · transition: ${workflow.transitionSeq}`,
-    `Lease: ${workflowLease(entry)}`,
+    `Lease: ${workflowLeaseLabel(entry)}`,
     availability.available.length > 0 ? `Outcomes: ${availability.available.join(", ")}` : "Outcomes: none",
     state?.prompt ? `Instruction: ${state.prompt}` : undefined,
     workflow.waitingMonitor ? `Waiting on monitor #${workflow.waitingMonitor.monitorId}` : undefined,

--- a/src/ui/workflow-presentation.ts
+++ b/src/ui/workflow-presentation.ts
@@ -67,6 +67,9 @@ export function formatWorkflowInspection(entry: LoopEntry): string {
     `Revision: ${workflow.definitionRevision} · transition: ${workflow.transitionSeq}`,
     `Lease: ${workflowLeaseLabel(entry)}`,
     availability.available.length > 0 ? `Outcomes: ${availability.available.join(", ")}` : "Outcomes: none",
+    availability.unavailable.length > 0
+      ? `Unavailable: ${availability.unavailable.map((item) => `${item.outcome} (${item.targetState} exhausted ${item.maxAttempts})`).join(", ")}`
+      : undefined,
     state?.prompt ? `Instruction: ${state.prompt}` : undefined,
     workflow.waitingMonitor ? `Waiting on monitor #${workflow.waitingMonitor.monitorId}` : undefined,
   ].filter((line): line is string => line !== undefined);

--- a/src/ui/workflow-presentation.ts
+++ b/src/ui/workflow-presentation.ts
@@ -1,0 +1,74 @@
+import { formatLastTransitionLines } from "../loop-format.js";
+import { displayRows, type ToolDisplayDetails, type ToolDisplayTone } from "../tools/tool-result.js";
+import type { LoopEntry } from "../types.js";
+import { getWorkflowOutcomeAvailability } from "../workflow-reducer.js";
+
+export function workflowAttemptLabel(entry: LoopEntry): string {
+  const workflow = entry.workflow;
+  if (!workflow) return "?";
+  const state = workflow.definition.states[workflow.currentState];
+  const attempt = workflow.attemptsByState[workflow.currentState] ?? 1;
+  return state?.maxAttempts ? `${attempt}/${state.maxAttempts}` : String(attempt);
+}
+
+function workflowLease(entry: LoopEntry): string {
+  const workflow = entry.workflow;
+  if (!workflow) return "unavailable";
+  const execution = workflow.activeExecution;
+  if (!execution) return workflow.definition.states[workflow.currentState]?.task ? "missing" : "not required";
+  return execution.lease ? `active until ${new Date(execution.lease.expiresAt).toISOString()}` : "unowned";
+}
+
+interface WorkflowDisplayOptions {
+  entry: LoopEntry;
+  action: string;
+  tone: ToolDisplayTone;
+  summary: string;
+  extra?: string[];
+}
+
+export function workflowDisplayDetails({
+  entry,
+  action,
+  tone,
+  summary,
+  extra = [],
+}: WorkflowDisplayOptions): ToolDisplayDetails {
+  const workflow = entry.workflow;
+  if (!workflow) {
+    return { kind: "workflow", action, tone, summary, expanded: displayRows(extra, 12) };
+  }
+  const state = workflow.definition.states[workflow.currentState];
+  const availability = getWorkflowOutcomeAvailability(workflow);
+  const lines = [
+    `Goal: ${entry.prompt}`,
+    `State: ${workflow.currentState} · revision ${workflow.definitionRevision} · transition ${workflow.transitionSeq}`,
+    `Attempt: ${workflowAttemptLabel(entry)}`,
+    state?.prompt ? `Instruction: ${state.prompt}` : undefined,
+    workflow.activeExecution ? `Work: ${workflow.activeExecution.subject} (${workflow.activeExecution.id})` : undefined,
+    `Lease: ${workflowLease(entry)}`,
+    availability.available.length > 0 ? `Outcomes: ${availability.available.join(", ")}` : undefined,
+    availability.unavailable.length > 0 ? `Unavailable: ${availability.unavailable.map((item) => item.outcome).join(", ")}` : undefined,
+    workflow.waitingMonitor ? `Waiting: monitor #${workflow.waitingMonitor.monitorId}` : undefined,
+    workflow.lastTransition ? formatLastTransitionLines(workflow.lastTransition).join("\n") : undefined,
+    ...extra,
+  ].filter((line): line is string => line !== undefined);
+  return { kind: "workflow", action, tone, summary, expanded: displayRows(lines, 12) };
+}
+
+export function formatWorkflowInspection(entry: LoopEntry): string {
+  const workflow = entry.workflow;
+  if (!workflow) return `#${entry.id}: ${entry.prompt}`;
+  const state = workflow.definition.states[workflow.currentState];
+  const availability = getWorkflowOutcomeAvailability(workflow);
+  const lines = [
+    `#${entry.id}: ${entry.prompt}`,
+    `State: ${workflow.currentState} · attempt ${workflowAttemptLabel(entry)}`,
+    `Revision: ${workflow.definitionRevision} · transition: ${workflow.transitionSeq}`,
+    `Lease: ${workflowLease(entry)}`,
+    availability.available.length > 0 ? `Outcomes: ${availability.available.join(", ")}` : "Outcomes: none",
+    state?.prompt ? `Instruction: ${state.prompt}` : undefined,
+    workflow.waitingMonitor ? `Waiting on monitor #${workflow.waitingMonitor.monitorId}` : undefined,
+  ].filter((line): line is string => line !== undefined);
+  return lines.join("\n");
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -26,8 +26,9 @@ function clearTestLoopStore(sessionId: string): void {
 }
 
 describe("workflow runtime wiring", () => {
-  beforeEach(() => clearTestLoopStore("workflow-session"));
-  afterEach(() => clearTestLoopStore("workflow-session"));
+  const sessionIds = ["workflow-cap-session", "workflow-task-session"];
+  beforeEach(() => sessionIds.forEach(clearTestLoopStore));
+  afterEach(() => sessionIds.forEach(clearTestLoopStore));
   it("pauses an immediately fired workflow state at its local fire cap", async () => {
     const { pi, toolMap, extensionHandlers } = createMockPi();
     extension(pi as any);
@@ -36,7 +37,7 @@ describe("workflow runtime wiring", () => {
     const ctx = {
       ui: { setStatus: vi.fn(), setWidget: vi.fn() },
       hasPendingMessages: () => false,
-      sessionManager: { getSessionId: () => "workflow-session" },
+      sessionManager: { getSessionId: () => "workflow-cap-session" },
     };
     for (const handler of extensionHandlers.get("turn_start") ?? []) {
       await handler(null, ctx);
@@ -61,7 +62,7 @@ describe("workflow runtime wiring", () => {
     expect(loops.content[0].text).toContain("[paused]");
   });
 
-  it("creates and completes external workflow tasks", async () => {
+  it("creates and completes task-bearing workflow work", async () => {
     const { pi, toolMap, extensionHandlers } = createMockPi({
       respondToTaskPing: true,
       respondToTaskCreate: () => "workflow-task",
@@ -73,7 +74,7 @@ describe("workflow runtime wiring", () => {
     const ctx = {
       ui: { setStatus: vi.fn(), setWidget: vi.fn() },
       hasPendingMessages: () => false,
-      sessionManager: { getSessionId: () => "workflow-session" },
+      sessionManager: { getSessionId: () => "workflow-task-session" },
     };
     for (const handler of extensionHandlers.get("turn_start") ?? []) {
       await handler(null, ctx);

--- a/test/loop-command.test.ts
+++ b/test/loop-command.test.ts
@@ -125,13 +125,15 @@ describe("registerLoopCommand", () => {
           investigate: {
             prompt: "Investigate evidence.",
             task: { subject: "Investigate", description: "Collect evidence." },
-            on: { ready: "done" },
+            on: { ready: "done", retry: "blocked" },
             maxAttempts: 2,
           },
+          blocked: { prompt: "Retry later.", maxAttempts: 1, on: { resume: "investigate" } },
           done: { prompt: "Report.", terminal: "completed" },
         },
       },
     });
+    h.store.get("1")!.workflow!.attemptsByState.blocked = 1;
     let loopListVisits = 0;
     let detailTitle = "";
     const ui = {
@@ -151,6 +153,7 @@ describe("registerLoopCommand", () => {
     expect(detailTitle).toContain("Revision: 1 · transition: 0");
     expect(detailTitle).toContain("Lease: unowned");
     expect(detailTitle).toContain("Outcomes: ready");
+    expect(detailTitle).toContain("Unavailable: retry (blocked exhausted 1)");
   });
 
   it("no-args invocation with 'Create scheduled loop' prompts for prompt + interval and creates a loop", async () => {

--- a/test/loop-command.test.ts
+++ b/test/loop-command.test.ts
@@ -115,6 +115,44 @@ describe("registerLoopCommand", () => {
     expect(ui.select).toHaveBeenCalledWith("No loops configured", ["< Back"]);
   });
 
+  it("shows workflow state, ownership, and outcomes in the interactive detail view", async () => {
+    h.store.create({ type: "dynamic" }, "Ship the migration", {
+      recurring: true,
+      workflow: {
+        version: 1,
+        initialState: "investigate",
+        states: {
+          investigate: {
+            prompt: "Investigate evidence.",
+            task: { subject: "Investigate", description: "Collect evidence." },
+            on: { ready: "done" },
+            maxAttempts: 2,
+          },
+          done: { prompt: "Report.", terminal: "completed" },
+        },
+      },
+    });
+    let loopListVisits = 0;
+    let detailTitle = "";
+    const ui = {
+      select: vi.fn(async (title: string, options: string[]) => {
+        if (title === "Loop") return "View loops";
+        if (title === "Loops") return loopListVisits++ === 0 ? options[0] : undefined;
+        detailTitle = title;
+        return "< Back";
+      }),
+      input: vi.fn(async () => undefined),
+      notify: vi.fn(),
+    };
+
+    await h.command.handler!("", { ui } as any);
+
+    expect(detailTitle).toContain("State: investigate · attempt 1/2");
+    expect(detailTitle).toContain("Revision: 1 · transition: 0");
+    expect(detailTitle).toContain("Lease: unowned");
+    expect(detailTitle).toContain("Outcomes: ready");
+  });
+
   it("no-args invocation with 'Create scheduled loop' prompts for prompt + interval and creates a loop", async () => {
     const ui = {
       select: vi.fn(async () => "Create scheduled loop"),

--- a/test/loop-tools.test.ts
+++ b/test/loop-tools.test.ts
@@ -412,6 +412,63 @@ describe("Workflow tools", () => {
     expect(h.onDynamicLoopActivated).toHaveBeenCalledWith(h.store.get("1"));
   });
 
+  it("renders workflow lifecycle results as compact expandable rows", async () => {
+    const createResult = await h.result("WorkflowCreate", { goal: "Fix the regression", definition: taskDefinition });
+    expect(createResult.details).toMatchObject({
+      kind: "workflow",
+      action: "create",
+      tone: "success",
+      summary: expect.stringMatching(/Workflow #1 active · investigate · attempt 1\/2/),
+    });
+    expect(createResult.details.expanded).toEqual(expect.arrayContaining([
+      "Goal: Fix the regression",
+      "State: investigate · revision 1 · transition 0",
+      expect.stringContaining("Outcomes: found"),
+    ]));
+
+    const transitionResult = await h.result("WorkflowTransition", { id: "1", outcome: "found", evidence: "Reproduced." });
+    expect(transitionResult.details).toMatchObject({
+      kind: "workflow",
+      action: "transition",
+      tone: "success",
+      summary: "Workflow #1 advanced · investigate → fix",
+    });
+
+    const claimResult = await h.result("WorkflowClaim", { id: "1" });
+    expect(claimResult.details).toMatchObject({
+      kind: "workflow",
+      action: "claim",
+      tone: "success",
+      summary: "Workflow #1 lease active · fix",
+    });
+
+    const reviseResult = await h.result("WorkflowRevise", {
+      id: "1",
+      expectedRevision: 1,
+      expectedState: "fix",
+      expectedTransitionSeq: 1,
+      reason: "Clarify retry work.",
+      changes: [{ op: "revise_state", stateId: "investigate", prompt: "Investigate revised requirements." }],
+    });
+    expect(reviseResult.details).toMatchObject({
+      kind: "workflow",
+      action: "revise",
+      tone: "success",
+      summary: "Workflow #1 revised · r1 → r2",
+    });
+  });
+
+  it("renders workflow rejections with compact recovery details", async () => {
+    const result = await h.result("WorkflowClaim", { id: "99" });
+    expect(result.details).toMatchObject({
+      kind: "workflow",
+      action: "claim",
+      tone: "error",
+      summary: "Workflow #99 claim rejected",
+      expanded: [expect.stringContaining("Loop #99 not found")],
+    });
+  });
+
   it("embeds initial task work without creating an external task", async () => {
     const out = await h.text("WorkflowCreate", { goal: "Fix the regression", definition: taskDefinition });
     expect(out).toContain("Active workflow work: Investigate regression (investigate:0)");

--- a/test/loop-tools.test.ts
+++ b/test/loop-tools.test.ts
@@ -418,7 +418,7 @@ describe("Workflow tools", () => {
       kind: "workflow",
       action: "create",
       tone: "success",
-      summary: expect.stringMatching(/Workflow #1 active · investigate · attempt 1\/2/),
+      summary: "Workflow #1 active · investigate · attempt 1",
     });
     expect(createResult.details.expanded).toEqual(expect.arrayContaining([
       "Goal: Fix the regression",

--- a/test/loop-tools.test.ts
+++ b/test/loop-tools.test.ts
@@ -469,6 +469,17 @@ describe("Workflow tools", () => {
     });
   });
 
+  it("distinguishes workflows from ordinary loops in LoopList presentation", async () => {
+    await h.result("WorkflowCreate", { goal: "Fix the regression", definition: taskDefinition });
+    const list = await h.result("LoopList", {});
+    expect(list.details).toMatchObject({
+      kind: "loop",
+      action: "list",
+      tone: "info",
+      summary: "1 workflow · 1 active",
+    });
+  });
+
   it("embeds initial task work without creating an external task", async () => {
     const out = await h.text("WorkflowCreate", { goal: "Fix the regression", definition: taskDefinition });
     expect(out).toContain("Active workflow work: Investigate regression (investigate:0)");

--- a/test/monitor-tools.test.ts
+++ b/test/monitor-tools.test.ts
@@ -1,5 +1,6 @@
+import { initTheme } from "@earendil-works/pi-coding-agent";
 import { Check } from "typebox/value";
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { LoopStore } from "../src/store.js";
 import { registerMonitorTools } from "../src/tools/monitor-tools.js";
 import type { MonitorEntry } from "../src/types.js";
@@ -53,6 +54,7 @@ function setup(managerOverrides: Partial<{
 }
 
 describe("MonitorCreate", () => {
+  beforeAll(() => initTheme("dark"));
   it("starts a monitor and reports the stream", async () => {
     const h = setup();
     const out = await h.text("MonitorCreate", { command: "npm test" });

--- a/test/monitor-tools.test.ts
+++ b/test/monitor-tools.test.ts
@@ -47,9 +47,9 @@ function setup(managerOverrides: Partial<{
     handleWorkflowMonitorWait,
   });
 
-  const text = async (name: string, args: any) =>
-    (await toolMap.get(name)!.execute!("t", args)).content[0].text as string;
-  return { store, manager, triggerSystem, handleMonitorDoneLoop, handleWorkflowMonitorWait, text, toolMap };
+  const result = async (name: string, args: any) => await toolMap.get(name)!.execute!("t", args);
+  const text = async (name: string, args: any) => (await result(name, args)).content[0].text as string;
+  return { store, manager, triggerSystem, handleMonitorDoneLoop, handleWorkflowMonitorWait, text, result, toolMap };
 }
 
 describe("MonitorCreate", () => {
@@ -63,8 +63,42 @@ describe("MonitorCreate", () => {
       prompt: expect.stringContaining("Monitor #1 timed out"),
       trigger: expect.objectContaining({ type: "event", source: "monitor:timeout" }),
     }), "1");
-    expect(h.toolMap.get("MonitorCreate")?.renderShell).toBe("self");
+    expect(h.toolMap.get("MonitorCreate")?.renderShell).not.toBe("self");
+    expect(h.toolMap.get("MonitorCreate")?.renderCall).toBeTypeOf("function");
     expect(h.toolMap.get("MonitorCreate")?.renderResult).toBeTypeOf("function");
+  });
+
+  it("renders monitor lifecycle results as visible compact rows", async () => {
+    const h = setup();
+    const createResult = await h.result("MonitorCreate", { command: "npm test", description: "Run tests" });
+    expect(createResult.details).toMatchObject({
+      kind: "monitor",
+      action: "create",
+      tone: "success",
+      summary: "Monitor #1 running · Run tests",
+    });
+
+    const theme = { fg: (_color: string, text: string) => text, bold: (text: string) => text } as any;
+    const call = (h.toolMap.get("MonitorCreate") as any).renderCall({ command: "npm test", description: "Run tests" }, theme);
+    expect(call.render(80).join("\n")).toContain("Monitor start · Run tests");
+    const rendered = (h.toolMap.get("MonitorCreate") as any).renderResult(
+      createResult,
+      { expanded: false, isPartial: false },
+      theme,
+    );
+    expect(rendered.render(80).join("\n")).toContain("Monitor #1 running");
+  });
+
+  it("keeps monitor failures visible in the transcript", async () => {
+    const h = setup();
+    const result = await h.result("MonitorCreate", { command: "npm test", workflowId: "1", onDone: "report" });
+    expect(result.details).toMatchObject({
+      kind: "monitor",
+      action: "create",
+      tone: "error",
+      summary: "Choose workflowId or onDone",
+    });
+    expect(h.toolMap.get("MonitorCreate")?.renderShell).not.toBe("self");
   });
 
   it("creates a one-shot completion loop and registers it when onDone is set", async () => {

--- a/test/monitor-tools.test.ts
+++ b/test/monitor-tools.test.ts
@@ -91,6 +91,21 @@ describe("MonitorCreate", () => {
     expect(rendered.render(80).join("\n")).toContain("Monitor #1 running");
   });
 
+  it("renders concise calls for list, progress, and stop actions", () => {
+    const h = setup();
+    const theme = { fg: (_color: string, text: string) => text, bold: (text: string) => text } as any;
+    const cases = [
+      ["MonitorList", {}, "Monitor status"],
+      ["MonitorUpdate", { monitorId: "4" }, "Monitor update · #4"],
+      ["MonitorStop", { monitorId: "4" }, "Monitor stop · #4"],
+    ] as const;
+
+    for (const [name, args, expected] of cases) {
+      const call = (h.toolMap.get(name) as any).renderCall(args, theme);
+      expect(call.render(80).join("\n")).toContain(expected);
+    }
+  });
+
   it("keeps monitor failures visible in the transcript", async () => {
     const h = setup();
     const result = await h.result("MonitorCreate", { command: "npm test", workflowId: "1", onDone: "report" });

--- a/test/tool-renderer.test.ts
+++ b/test/tool-renderer.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { initTheme } from "@earendil-works/pi-coding-agent";
+import { beforeAll, describe, expect, it } from "vitest";
 import { displayRows, textResult } from "../src/tools/tool-result.js";
 import { hideToolTranscript, renderToolCall, renderToolResult, toolArg } from "../src/ui/tool-renderer.js";
 
@@ -8,6 +9,7 @@ const theme = {
 } as any;
 
 describe("Pi tool renderer", () => {
+  beforeAll(() => initTheme("dark"));
   it("renders a compact result until the user expands it", () => {
     const result = {
       content: [{ type: "text" as const, text: "full model-facing result" }],
@@ -17,15 +19,17 @@ describe("Pi tool renderer", () => {
         tone: "success" as const,
         summary: "Workflow #1 active · investigate · task #1",
         expanded: ["Goal: workflow smoke test", "Outcome: evidence_found"],
+        expandable: true,
       },
     };
 
     const collapsed = renderToolResult(result, { expanded: false, isPartial: false }, theme);
     const expanded = renderToolResult(result, { expanded: true, isPartial: false }, theme);
 
-    expect(collapsed.render(120).map((line) => line.trimEnd())).toEqual([
-      expect.stringMatching(/^✓ Workflow #1 active · investigate · task #1.*expand/),
-    ]);
+    const collapsedLines = collapsed.render(120).map((line) => line.trimEnd());
+    expect(collapsedLines).toHaveLength(1);
+    expect(collapsedLines[0]).toContain("✓ Workflow #1 active · investigate · task #1");
+    expect(collapsedLines[0]).toContain("expand");
     expect(expanded.render(120).map((line) => line.trimEnd())).toEqual([
       "✓ Workflow #1 active · investigate · task #1",
       "Goal: workflow smoke test",

--- a/test/tool-renderer.test.ts
+++ b/test/tool-renderer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { displayRows } from "../src/tools/tool-result.js";
+import { displayRows, textResult } from "../src/tools/tool-result.js";
 import { hideToolTranscript, renderToolCall, renderToolResult, toolArg } from "../src/ui/tool-renderer.js";
 
 const theme = {
@@ -23,12 +23,39 @@ describe("Pi tool renderer", () => {
     const collapsed = renderToolResult(result, { expanded: false, isPartial: false }, theme);
     const expanded = renderToolResult(result, { expanded: true, isPartial: false }, theme);
 
-    expect(collapsed.render(120).map((line) => line.trimEnd())).toEqual(["✓ Workflow #1 active · investigate · task #1"]);
+    expect(collapsed.render(120).map((line) => line.trimEnd())).toEqual([
+      expect.stringMatching(/^✓ Workflow #1 active · investigate · task #1.*expand/),
+    ]);
     expect(expanded.render(120).map((line) => line.trimEnd())).toEqual([
       "✓ Workflow #1 active · investigate · task #1",
       "Goal: workflow smoke test",
       "Outcome: evidence_found",
     ]);
+  });
+
+  it("keeps meaningful progress identity while a result is partial", () => {
+    const component = renderToolResult({
+      content: [{ type: "text", text: "starting monitor" }],
+      details: {
+        kind: "monitor",
+        action: "create",
+        tone: "info",
+        summary: "Monitor #4 starting · npm test",
+      },
+    }, { expanded: false, isPartial: true }, theme);
+
+    expect(component.render(40).join("\n")).toContain("Monitor #4 starting");
+  });
+
+  it("shows unexpected tool errors even without display metadata", () => {
+    const component = (renderToolResult as any)(
+      { content: [{ type: "text", text: "process spawn failed" }] },
+      { expanded: false, isPartial: false },
+      theme,
+      { isError: true } as any,
+    );
+
+    expect(component.render(80).join("\n")).toContain("✕ process spawn failed");
   });
 
   it("renders a concise call label", () => {
@@ -64,6 +91,18 @@ describe("Pi tool renderer", () => {
     );
 
     expect(component.render(120).map((line) => line.trimEnd())).toEqual(["• 200 tasks · 200 pending · 0 active"]);
+  });
+
+  it("bounds display metadata by physical lines", () => {
+    expect(displayRows(["first\nsecond", "third"], 2)).toEqual([
+      "first", "second", "… 1 more",
+    ]);
+  });
+
+  it("truncates oversized model-facing tool content", () => {
+    const result = textResult(Array.from({ length: 2100 }, (_value, index) => `line ${index + 1}`).join("\n"));
+    expect(result.content[0].text.split("\n").length).toBeLessThanOrEqual(2002);
+    expect(result.content[0].text).toContain("Output truncated");
   });
 
   it("bounds display metadata for large lists", () => {

--- a/test/tool-renderer.test.ts
+++ b/test/tool-renderer.test.ts
@@ -1,4 +1,6 @@
+import { readFileSync, rmSync } from "node:fs";
 import { initTheme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { beforeAll, describe, expect, it } from "vitest";
 import { displayRows, textResult } from "../src/tools/tool-result.js";
 import { hideToolTranscript, renderToolCall, renderToolResult, toolArg } from "../src/ui/tool-renderer.js";
@@ -62,6 +64,32 @@ describe("Pi tool renderer", () => {
     expect(component.render(80).join("\n")).toContain("✕ process spawn failed");
   });
 
+  it("bounds expanded details by rendered terminal lines", () => {
+    const component = renderToolResult({
+      content: [{ type: "text", text: "model content" }],
+      details: {
+        kind: "workflow",
+        action: "create",
+        tone: "success",
+        summary: "Workflow #1 active",
+        expanded: ["A very long workflow instruction ".repeat(30)],
+        expandable: true,
+      },
+    }, { expanded: true, isPartial: false }, theme);
+
+    const lines = component.render(24);
+    expect(lines.length).toBeLessThanOrEqual(14);
+    expect(lines.at(-1)).toContain("more visual lines");
+  });
+
+  it("normalizes and width-bounds call summaries onto one row", () => {
+    const render = renderToolCall("Monitor", () => `start · first line\n${"second line ".repeat(20)}`);
+    const lines = render({}, theme).render(32);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("Monitor start · first line");
+    expect(visibleWidth(lines[0])).toBeLessThanOrEqual(32);
+  });
+
   it("renders a concise call label", () => {
     const render = renderToolCall("Monitor", () => "start · npm test");
     expect(render({}, theme).render(120).map((line) => line.trimEnd())).toEqual(["Monitor start · npm test"]);
@@ -103,10 +131,18 @@ describe("Pi tool renderer", () => {
     ]);
   });
 
-  it("truncates oversized model-facing tool content", () => {
-    const result = textResult(Array.from({ length: 2100 }, (_value, index) => `line ${index + 1}`).join("\n"));
+  it("truncates oversized model content while preserving retrievable full output", () => {
+    const fullContent = Array.from({ length: 2100 }, (_value, index) => `line ${index + 1}`).join("\n");
+    const result = textResult(fullContent);
     expect(result.content[0].text.split("\n").length).toBeLessThanOrEqual(2002);
     expect(result.content[0].text).toContain("Output truncated");
+    const fullOutputPath = result.content[0].text.match(/Full output: (.+)]$/)?.[1];
+    expect(fullOutputPath).toBeDefined();
+    try {
+      expect(readFileSync(fullOutputPath!, "utf8")).toBe(fullContent);
+    } finally {
+      if (fullOutputPath) rmSync(fullOutputPath, { force: true });
+    }
   });
 
   it("bounds display metadata for large lists", () => {

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -141,6 +141,35 @@ describe("LoopWidget status rendering", () => {
     expect(latestStatusCall()).toEqual(["loops", "↻ 1 loop · ▶ 1 monitor"]);
   });
 
+  it("shows workflow count and active phase separately from ordinary loops", () => {
+    store.create(
+      { type: "dynamic" },
+      "Ship migration",
+      {
+        recurring: true,
+        workflow: {
+          version: 1,
+          initialState: "investigate",
+          states: {
+            investigate: {
+              prompt: "Investigate.",
+              task: { subject: "Investigate", description: "Collect evidence." },
+              maxAttempts: 2,
+              on: { ready: "done" },
+            },
+            done: { prompt: "Report.", terminal: "completed" },
+          },
+        },
+      },
+    );
+
+    widget.update();
+    expect(latestStatusCall()).toEqual([
+      "loops",
+      "◆ 1 workflow | #1 investigate · attempt 1/2 · unowned",
+    ]);
+  });
+
   it("does not count one-shot monitor completion loops as visible loops in status", () => {
     store.create(
       { type: "event", source: "monitor:done", filter: '{"monitorId":"5"}' },


### PR DESCRIPTION
## Summary

- unify workflow, monitor, loop, task, command, and widget presentation around compact Pi-native summaries with bounded expandable details
- make every workflow lifecycle result and monitor action visible, error-aware, and width-safe without dumping model-facing payloads into the collapsed TUI
- add workflow-aware `/loop` inspection, status-widget phase/lease context, retrievable full-output truncation, and deterministic runtime regressions

