### PR TITLE
fix(workflow): continue across ordinary phase gaps

### DIFF
--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -122,6 +122,11 @@ function stateLoopStartsImmediately(entry: LoopEntry): boolean {
   return Boolean(entry.workflow && getActiveWorkflowStateLoop(entry.workflow)?.startImmediately);
 }
 
+/** Ordinary phases wake immediately; cadenced states only when startImmediately is set. */
+function stateShouldWakeImmediately(entry: LoopEntry): boolean {
+  return !entry.workflow || !getActiveWorkflowStateLoop(entry.workflow) || stateLoopStartsImmediately(entry);
+}
+
 function formatWorkflowDefinitionError(error: string | undefined): string {
   return `Workflow definition rejected: ${error ?? "unknown validation error"}\nRequired fields: version: 1, initialState, and states.\nExample definition:\n${WORKFLOW_DEFINITION_EXAMPLE}\nNext: correct the JSON and call WorkflowCreate again.`;
 }
@@ -153,7 +158,11 @@ export function formatWorkflowSummary(entry: LoopEntry, heading: string, failure
     return `${message}\nNeeds attention: this state declares no outcomes ("on"). Add on: {outcome: targetState} to advance it.`;
   }
   if (availability.available.length === 0) return `${message}\nBlocked: all declared outcomes are unavailable.`;
-  return `${message}\nChoose outcome: ${availability.available.join(", ")}\nNext: WorkflowTransition({ id: "${entry.id}", outcome: "${availability.available[0]}", evidence: "..." })`;
+  const outcomes = availability.available.join(", ");
+  if (execution && !execution.lease) {
+    return `${message}\nChoose outcome: ${outcomes}\nNext: WorkflowClaim({ id: "${entry.id}" }), then complete the work and call WorkflowTransition({ id: "${entry.id}", outcome: "${availability.available[0]}", evidence: "..." })`;
+  }
+  return `${message}\nChoose outcome: ${outcomes}\nNext: WorkflowTransition({ id: "${entry.id}", outcome: "${availability.available[0]}", evidence: "..." })`;
 }
 
 export function registerWorkflowTools(options: WorkflowToolsOptions): void {
@@ -199,7 +208,7 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
       });
       getTriggerSystem().add(entry);
       updateWidget();
-      if (!entry.workflow || !getActiveWorkflowStateLoop(entry.workflow) || stateLoopStartsImmediately(entry)) onDynamicLoopActivated?.(entry);
+      if (stateShouldWakeImmediately(entry)) onDynamicLoopActivated?.(entry);
       const wake = entry.workflow && getActiveWorkflowStateLoop(entry.workflow)
         ? "scheduled from the active state cadence."
         : "the state instruction will be delivered when the agent becomes idle.";
@@ -403,7 +412,7 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
       }
       const resumed = entry.status === "paused" ? store.resume(entry.id) ?? entry : entry;
       getTriggerSystem().add(resumed);
-      if (stateLoopStartsImmediately(resumed)) onDynamicLoopActivated?.(resumed);
+      if (stateShouldWakeImmediately(resumed)) onDynamicLoopActivated?.(resumed);
       const transition = `${resumed.workflow?.lastTransition?.from ?? "?"} → ${resumed.workflow?.currentState ?? "?"}`;
       return textResult(
         `Workflow #${resumed.id} advanced: ${transition}\n${formatWorkflowSummary(resumed, `Workflow #${resumed.id} — ${resumed.status}`)}`,

--- a/test/e2e/workflow-conformance.mjs
+++ b/test/e2e/workflow-conformance.mjs
@@ -113,6 +113,27 @@ const SCENARIOS = {
       return definition;
     },
   },
+  continuation: {
+    prompt: [
+      "Run a live continuation exercise for the durable workflow tools installed in this session.",
+      "Goal: model a three-phase task pipeline — gather, build, verify — and run it all the way to terminal completion in one continuous effort.",
+      "Embed each phase's work in that phase's state; do not create separate tasks.",
+      "After you transition out of a phase, the next phase's work is entered unowned. Claim it yourself, do the work, and transition again — do not stop or wait for another message between phases.",
+      "Use only the workflow tools this session provides; do not create standalone tasks, loops, or monitors.",
+      "When a workflow tool reports terminal completion, reply exactly LIVE_WORKFLOW_DONE and nothing else.",
+    ].join("\n"),
+    validateDefinition(args) {
+      const definition = parseDefinition(args);
+      const states = Object.values(definition.states ?? {});
+      if (states.filter((state) => state?.task?.subject).length !== 3) {
+        throw new Error("definition must embed exactly three task phases");
+      }
+      if (states.filter((state) => state?.terminal).length !== 1) {
+        throw new Error("definition must declare exactly one terminal state");
+      }
+      return definition;
+    },
+  },
 };
 
 const scenarioName = process.env.PI_LOOP_LIVE_SCENARIO ?? "retry";
@@ -151,9 +172,14 @@ function validate() {
   validateDefinition(successfulCreates[0].args);
   if (taskClaims.length !== 0) throw new Error(`expected zero TaskClaim calls, got ${taskClaims.length}`);
   if (workflowClaims.length === 0) throw new Error("expected WorkflowClaim after entering unowned task work");
-  const expectedTransitions = scenarioName === "evolution" ? 3 : 2;
+  const expectedTransitions = scenarioName === "evolution" ? 3 : scenarioName === "continuation" ? 3 : 2;
   if (transitions.length < expectedTransitions) {
     throw new Error(`expected at least ${expectedTransitions} WorkflowTransition calls, got ${transitions.length}`);
+  }
+  if (scenarioName === "continuation") {
+    if (workflowClaims.length < 2) {
+      throw new Error(`expected at least two self-claims across destination phases, got ${workflowClaims.length}`);
+    }
   }
   if (scenarioName === "evolution" && revisions.length !== 1) {
     throw new Error(`expected exactly one WorkflowRevise call, got ${revisions.length}`);

--- a/test/loop-tools.test.ts
+++ b/test/loop-tools.test.ts
@@ -624,6 +624,49 @@ describe("Workflow tools", () => {
     expect(message.indexOf("to_bb")).toBeLessThan(message.indexOf("to_aa"));
   });
 
+  it("queues the next wake after transitioning into an ordinary no-loop phase", async () => {
+    await h.text("WorkflowCreate", { goal: "Fix the regression", definition: taskDefinition });
+    h.onDynamicLoopActivated.mockClear();
+    await h.text("WorkflowTransition", { id: "1", outcome: "found", evidence: "Reproduced locally." });
+    expect(h.onDynamicLoopActivated).toHaveBeenCalledTimes(1);
+    expect(h.onDynamicLoopActivated).toHaveBeenCalledWith(
+      expect.objectContaining({ workflow: expect.objectContaining({ currentState: "fix" }) }),
+    );
+  });
+
+  it("keeps scheduled non-immediate cadence destinations dormant until their schedule", async () => {
+    const cadencedDefinition = JSON.stringify({
+      version: 1,
+      initialState: "investigate",
+      states: {
+        investigate: {
+          prompt: "Find the cause.",
+          task: { subject: "Investigate regression", description: "Find the root cause." },
+          on: { found: "fix" },
+        },
+        fix: {
+          prompt: "Fix it.",
+          task: { subject: "Fix regression", description: "Apply the fix." },
+          loop: { schedule: "0 0 * * *", maxFires: 2, startImmediately: false },
+          on: { passing: "done" },
+        },
+        done: { prompt: "Report completion.", terminal: "completed" },
+      },
+    });
+    await h.text("WorkflowCreate", { goal: "Fix the regression", definition: cadencedDefinition });
+    h.onDynamicLoopActivated.mockClear();
+    await h.text("WorkflowTransition", { id: "1", outcome: "found", evidence: "Reproduced locally." });
+    expect(h.onDynamicLoopActivated).not.toHaveBeenCalled();
+  });
+
+  it("directs WorkflowClaim before work and transition when the destination lease is unowned", async () => {
+    await h.text("WorkflowCreate", { goal: "Fix the regression", definition: taskDefinition });
+    const out = await h.text("WorkflowTransition", { id: "1", outcome: "found", evidence: "Reproduced locally." });
+    expect(out).toContain('Next: WorkflowClaim({ id: "1" })');
+    expect(out).toContain("then complete the work and call WorkflowTransition");
+    expect(out).not.toMatch(/^Next: WorkflowTransition\(/m);
+  });
+
   it("rejects an undeclared outcome without changing the workflow", async () => {
     await h.text("WorkflowCreate", { goal: "Fix the regression", definition: taskDefinition });
     const out = await h.text("WorkflowTransition", { id: "1", outcome: "ship_it" });


### PR DESCRIPTION
## Summary

Fixes the reported gap where an agent stalls between workflow task phases instead of automatically continuing.

- **Immediate next-phase wake**: `WorkflowTransition` now queues the next hidden wake when entering an ordinary no-loop phase, mirroring `WorkflowCreate`. Previously only cadenced states with `startImmediately` fired immediately; ordinary phases waited on a later scheduler pump/heartbeat.
- **Cadence preserved**: destination states with `loop.startImmediately:false` stay dormant until their schedule.
- **Claim-first guidance**: unowned destination summaries now direct `WorkflowClaim` before executing work and transitioning, instead of suggesting a transition that the missing lease would reject.
- **Unscripted live regression**: new `continuation` scenario proves a model self-claims each unowned destination phase and reaches terminal completion without `WorkflowClaim` being scripted in the prompt.

Unowned destination authority and `LoopStore` single-authority boundaries are unchanged.

## Validation

- `npm test -- --run` → 694 passed
- `npm run test:coverage` → 96.27% functions
- `npm run test:property` → 11 passed
- `npm run typecheck` → clean
- `npm run lint` → only the four established optional-chain warnings
- `npm run build && npm run test:package` → passed
- `npm audit --audit-level=moderate` → 0 vulnerabilities
- Live `continuation` harness (`.artifacts/live-workflow-continuation/latest.json`) → passed
