### PR TITLE
fix(monitor): renew timeout on activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ LoopDelete id="1"
 
 `/loop event tasks:created ...` is treated as an explicit task-backlog worker: it adopts existing unfinished tasks, coalesces task-creation bursts, and re-wakes after each agent turn until the backlog drains. Tool callers opt into the same behavior with `taskBacklog=true`. Worker wakes are action-first: `TaskList`, claim/resume, concrete same-turn work, validation, then evidence—not a state report or promise to start on a later wake.
 
-Run work in the background and wake the agent when it succeeds, fails, or times out:
+Run work in the background and wake the agent when it succeeds, fails, or becomes inactive:
 
 ```text
 MonitorCreate command="python train.py" onDone="Analyze results and report best loss"
@@ -43,7 +43,7 @@ MonitorStop monitorId="1"
 
 - Cron, event, hybrid, dynamic goal, and opt-in workflow loops
 - Idle-safe agent re-wakes with dynamic-loop restart/session-switch recovery
-- Background command monitoring with buffered output, `onDone` wakes, and timeout alerts
+- Background command monitoring with buffered output, `onDone` wakes, and renewable inactivity alerts
 - Optional `pi-tasks` integration and a native task fallback
 - Session-isolated persistence and a compact TUI status line
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -95,7 +95,7 @@ pi-loop probes external `pi-tasks` through protocol-v2 RPC. When unavailable, th
 
 ## Monitors
 
-`MonitorCreate` spawns a detached process group, buffers bounded output, emits rate-limited progress, and records terminal status in memory. `MonitorStop` sends TERM then KILL fallback. `onDone` creates a one-shot completion wake; `workflowId` pauses a workflow state's cadence until terminal monitor outcome.
+`MonitorCreate` spawns a detached process group, buffers bounded output, emits rate-limited progress, and records terminal status in memory. Its `timeout` is a renewable inactivity threshold: stdout/stderr bytes, JSONL progress, and `MonitorUpdate` renew the deadline; total runtime alone never stops an active monitor. `MonitorStop` sends TERM then KILL fallback. `onDone` creates a one-shot completion wake; `workflowId` pauses a workflow state's cadence until terminal monitor outcome.
 
 Monitor events:
 

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -133,10 +133,10 @@ Output is buffered and emitted as `monitor:output`. A monitor finishes as one of
 
 - clean exit: emits `monitor:done`
 - nonzero exit or spawn failure: emits `monitor:error`
-- timeout: stops the process, emits `monitor:error`, and always wakes the agent after the process reaps
+- inactivity timeout: stops the process after no output or structured progress, emits `monitor:error`, and always wakes the agent after the process reaps
 - explicit `MonitorStop`: cancels the monitor without an `onDone` wake; workflow-owned monitors resume their current state with `status=stopped`
 
-Pass `onDone` whenever the agent should resume work after success or failure. Its one-shot wake also fires on timeout; monitors without `onDone` still send a timeout-only alert. The default timeout is five minutes; use `timeout=0` to disable it.
+Pass `onDone` whenever the agent should resume work after success or failure. Its one-shot wake also fires on timeout; monitors without `onDone` still send a timeout-only alert. `timeout` is an inactivity threshold, not a total-runtime limit: stdout/stderr bytes, JSONL progress, and `MonitorUpdate` renew it. The default is five quiet minutes; use `timeout=0` to disable stale detection.
 
 For a monitor launched from an active workflow, use `workflowId` instead of `onDone`:
 

--- a/src/monitor-manager.ts
+++ b/src/monitor-manager.ts
@@ -21,6 +21,7 @@ const OUTPUT_EVENT_INTERVAL_MS = 1000;
 const MAX_OUTPUT_LINE_LENGTH = 4096;
 const OUTPUT_RATE_WINDOW_MS = 60000;
 export const MONITOR_RETENTION_MS = 15 * 60 * 1000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 export class MonitorManager {
   private processes = new Map<string, MonitorProcess>();
@@ -115,6 +116,31 @@ export class MonitorManager {
     bp.deadlineTimer = undefined;
   }
 
+  private markActivity(bp: MonitorProcess): void {
+    if (this.shuttingDown || bp.entry.status !== "running") return;
+    bp.lastActivityAt = Date.now();
+    bp.lastActivityMonotonic = globalThis.performance.now();
+  }
+
+  private scheduleInactivityCheck(id: string, bp: MonitorProcess, delay = bp.entry.timeout): void {
+    if (bp.deadlineTimer || this.shuttingDown || bp.entry.status !== "running" || bp.entry.timeout <= 0) return;
+
+    const deadlineTimer = setTimeout(() => {
+      if (bp.deadlineTimer !== deadlineTimer) return;
+      bp.deadlineTimer = undefined;
+      if (this.shuttingDown || bp.entry.status !== "running") return;
+
+      const remaining = bp.entry.timeout - (globalThis.performance.now() - bp.lastActivityMonotonic);
+      if (remaining > 0) {
+        this.scheduleInactivityCheck(id, bp, remaining);
+        return;
+      }
+      void this.stop(id, "timeout");
+    }, Math.min(Math.max(1, delay), MAX_TIMER_DELAY_MS));
+    deadlineTimer.unref?.();
+    bp.deadlineTimer = deadlineTimer;
+  }
+
   private signalProcessTree(bp: MonitorProcess, signal: NodeJS.Signals): void {
     let fellBack = false;
     const fallback = () => {
@@ -167,6 +193,9 @@ export class MonitorManager {
   }
 
   create(command: string, description?: string, timeout = 300000): MonitorEntry {
+    if (!Number.isFinite(timeout) || timeout < 0) {
+      throw new Error("Monitor timeout must be a finite nonnegative number");
+    }
     const now = Date.now();
     const result = reduceMonitorState(this.toReducerState(), {
       type: "MONITOR_CREATED",
@@ -200,6 +229,8 @@ export class MonitorManager {
       completionCallbacks: [],
       terminalCallbacks: [],
       terminalReady: false,
+      lastActivityAt: now,
+      lastActivityMonotonic: globalThis.performance.now(),
       lastOutputEventAt: 0,
       lastProgressChangeAt: 0,
       pendingOutputLines: 0,
@@ -215,8 +246,8 @@ export class MonitorManager {
 
     const finish = (code: number | null, status: "completed" | "error") => {
       if (this.shuttingDown) return;
-      this.clearDeadline(bp);
       this.flushOutput(id, bp);
+      this.clearDeadline(bp);
       this.emitOutputProgress(id, bp);
       this.applyReducerEvent({
         type: status === "completed" ? "MONITOR_COMPLETED" : "MONITOR_ERRORED",
@@ -259,8 +290,8 @@ export class MonitorManager {
 
     child.on("error", (err) => {
       if (!this.shuttingDown && bp.entry.status === "running") {
-        this.clearDeadline(bp);
         this.flushOutput(id, bp);
+        this.clearDeadline(bp);
         this.emitOutputProgress(id, bp);
         this.applyReducerEvent({
           type: "MONITOR_ERRORED",
@@ -293,15 +324,7 @@ export class MonitorManager {
       }
     });
 
-    if (timeout > 0) {
-      const deadlineTimer = setTimeout(() => {
-        if (!this.shuttingDown && bp.entry.status === "running") {
-          void this.stop(id, "timeout");
-        }
-      }, timeout);
-      deadlineTimer.unref?.();
-      bp.deadlineTimer = deadlineTimer;
-    }
+    this.scheduleInactivityCheck(id, bp);
 
     this.processes.set(id, bp);
     this.emit("monitor:started", {
@@ -321,7 +344,7 @@ export class MonitorManager {
 
   list(): MonitorEntry[] {
     return Array.from(this.processes.values())
-      .map(bp => bp.entry)
+      .map(bp => ({ ...bp.entry, lastActivityAt: bp.lastActivityAt }))
       .sort((a, b) => Number(a.id) - Number(b.id));
   }
 
@@ -378,7 +401,7 @@ export class MonitorManager {
     if (reason === "timeout") {
       this.emit("monitor:error", {
         monitorId: id,
-        error: `Timed out after ${bp.entry.timeout}ms`,
+        error: `No monitor activity for ${bp.entry.timeout}ms`,
         outputLines: bp.entry.outputLines,
       });
       for (const callback of bp.completionCallbacks) callback(bp.entry);
@@ -451,6 +474,7 @@ export class MonitorManager {
 
   private handleOutput(id: string, bp: MonitorProcess, stream: "stdout" | "stderr", data: Buffer): void {
     if (this.shuttingDown) return;
+    if (data.length > 0) this.markActivity(bp);
     const decoder = stream === "stdout" ? bp.stdoutDecoder : bp.stderrDecoder;
     const remainderKey = stream === "stdout" ? "stdoutRemainder" : "stderrRemainder";
     const records = `${bp[remainderKey]}${decoder.write(data)}`.split("\n");
@@ -527,7 +551,10 @@ export class MonitorManager {
       payload: { id, progress },
     });
     const bp = this.processes.get(id);
-    if (bp) this.scheduleProgressChange(bp);
+    if (bp) {
+      this.markActivity(bp);
+      this.scheduleProgressChange(bp);
+    }
   }
 
   private scheduleProgressChange(bp: MonitorProcess): void {

--- a/src/tools/monitor-tools.ts
+++ b/src/tools/monitor-tools.ts
@@ -48,10 +48,18 @@ function formatRemaining(ms: number): string {
 }
 
 function formatActivity(monitor: MonitorEntry): string | undefined {
-  const lastActivityAt = monitor.lastOutputAt ?? monitor.startedAt;
-  const silence = Date.now() - lastActivityAt;
+  const now = Date.now();
+  const lastActivityAt = Math.max(
+    monitor.startedAt,
+    monitor.lastActivityAt ?? 0,
+    monitor.lastOutputAt ?? 0,
+    monitor.progress?.updatedAt ?? 0,
+  );
+  const silence = now - lastActivityAt;
   if (silence >= 60000) return `quiet ${formatRemaining(silence)}`;
-  if (monitor.outputRatePerMinute !== undefined) return `${monitor.outputRatePerMinute} lines/min`;
+  if (monitor.lastOutputAt !== undefined && now - monitor.lastOutputAt < 60000 && monitor.outputRatePerMinute !== undefined) {
+    return `${monitor.outputRatePerMinute} lines/min`;
+  }
   return undefined;
 }
 
@@ -68,10 +76,10 @@ export function registerMonitorTools(options: MonitorToolsOptions): void {
 
   pi.registerTool({ name: "MonitorCreate", label: "MonitorCreate",
   renderCall: renderToolCall("Monitor", (args) => `start · ${String(toolArg(args, "description") ?? toolArg(args, "command") ?? "background command").slice(0, 56)}`),
-  renderResult: renderToolResult, description: `Run a long command in the background while the agent continues. Use MonitorList for status/output; do not poll with shell sleep loops.\n\nTimed monitors always wake the agent if they time out. Pass onDone to create a completion wake for success, failure, or timeout. Pass workflowId to pause its workflow until a terminal result. Commands may emit JSONL progress as {"progress":{...}}; otherwise use MonitorUpdate.`, promptGuidelines: ["Use MonitorCreate for builds, CI checks, experiments, and other commands that need not block the turn.", "Use onDone when the agent must resume automatically after success or failure; timed monitors already alert on timeout.", "For an active workflow, use workflowId instead of onDone and await its completion wake."], parameters: Type.Object({
+  renderResult: renderToolResult, description: `Run a long command in the background while the agent continues. Use MonitorList for status/output; do not poll with shell sleep loops.\n\nThe timeout measures inactivity, not total runtime: output or structured progress renews it. Stale monitors always wake the agent. Pass onDone for a completion wake, or workflowId to pause a workflow until terminal. Commands may emit JSONL progress as {"progress":{...}}; otherwise use MonitorUpdate.`, promptGuidelines: ["Use MonitorCreate for builds, CI checks, experiments, and other commands that need not block the turn.", "Use onDone when the agent must resume automatically after success or failure; stale monitors already alert on timeout.", "For an active workflow, use workflowId instead of onDone and await its completion wake."], parameters: Type.Object({
     command: Type.String({ description: "Shell command to run in background" }),
     description: Type.Optional(Type.String({ description: "Human-readable description" })),
-    timeout: Type.Optional(Type.Number({ description: "Auto-stop after N ms (default: 300000, 0 = no timeout)", default: 300000 })),
+    timeout: Type.Optional(Type.Number({ description: "Stop after N ms without output or progress (default: 300000, 0 = disabled)", default: 300000, minimum: 0 })),
     onDone: Type.Optional(Type.String({ description: "Prompt to run when the monitor completes. Auto-creates a one-shot completion wake — no need for a separate LoopCreate." })),
     workflowId: Type.Optional(Type.String({ description: "Active workflow loop to pause until this monitor reaches a terminal status" })),
   }),
@@ -134,7 +142,7 @@ export function registerMonitorTools(options: MonitorToolsOptions): void {
       const timeoutTrigger: Trigger = { type: "event", source: "monitor:timeout", filter: JSON.stringify({ monitorId: entry.id }) };
       const timeoutLoop = store.create(
         timeoutTrigger,
-        `Monitor #${entry.id} timed out. Inspect MonitorList, report the failure, and decide whether to retry with a smaller bounded command.`,
+        `Monitor #${entry.id} became stale after ${entry.timeout}ms without output or progress. Inspect MonitorList, report the failure, and decide whether to retry or recover the command.`,
         { recurring: false },
       );
       handleMonitorDoneLoop(timeoutLoop, entry.id);
@@ -144,7 +152,7 @@ export function registerMonitorTools(options: MonitorToolsOptions): void {
     return Promise.resolve(textResult(
       `Monitor #${entry.id} started: ${entry.command.slice(0, 60)}\n` +
       `Progress: MonitorList shows the live output tail; monitor:output is rate-limited (monitorId: ${entry.id})\n` +
-      `Timeout: ${params.timeout ? `${params.timeout / 1000}s` : "none"}${workflowMsg}${onDoneMsg}`,
+      `Inactivity timeout: ${entry.timeout > 0 ? `${entry.timeout / 1000}s` : "none"}${workflowMsg}${onDoneMsg}`,
       {
         kind: "monitor",
         action: "create",
@@ -152,7 +160,7 @@ export function registerMonitorTools(options: MonitorToolsOptions): void {
         summary: `Monitor #${entry.id} running · ${params.description ?? entry.command.slice(0, 48)}`,
         expanded: [
           `Command: ${entry.command}`,
-          `Timeout: ${params.timeout ? `${params.timeout / 1000}s` : "none"}`,
+          `Inactivity timeout: ${entry.timeout > 0 ? `${entry.timeout / 1000}s` : "none"}`,
           workflow ? `Workflow #${workflow.id}: waiting for terminal monitor outcome` : params.onDone ? "Completion wake: enabled" : entry.timeout > 0 ? "Timeout alert: enabled" : "Completion wake: off",
         ],
       },
@@ -211,7 +219,7 @@ export function registerMonitorTools(options: MonitorToolsOptions): void {
     label: "MonitorUpdate",
     renderCall: renderToolCall("Monitor", (args) => `update · #${String(toolArg(args, "monitorId") ?? "?")}`),
     renderResult: renderToolResult,
-    description: "Set trustworthy structured progress for a running monitor that cannot emit JSONL. Pass monitorId and current/total or message. Do not use it for raw output or polling; use MonitorList.",
+    description: "Set trustworthy structured progress for a running monitor that cannot emit JSONL. This renews its inactivity timeout. Pass monitorId and current/total or message. Do not use it for raw output or polling; use MonitorList.",
     parameters: Type.Object({
       monitorId: Type.String({ description: "Monitor ID to update" }),
       current: Type.Optional(Type.Number({ description: "Completed work units" })),

--- a/src/types.ts
+++ b/src/types.ts
@@ -241,6 +241,7 @@ export interface MonitorEntry {
   stopReason?: "manual" | "timeout";
   outputLines: number;
   outputBuffer: string[];
+  lastActivityAt?: number;
   lastOutputAt?: number;
   outputRatePerMinute?: number;
   progress?: MonitorProgress;
@@ -272,6 +273,8 @@ export interface MonitorProcess {
   completionCallbacks: Array<(monitor: MonitorEntry) => void>;
   terminalCallbacks: Array<(monitor: MonitorEntry) => void>;
   terminalReady: boolean;
+  lastActivityAt: number;
+  lastActivityMonotonic: number;
   lastOutputEventAt: number;
   lastProgressChangeAt: number;
   progressChangeTimer?: ReturnType<typeof setTimeout>;

--- a/src/ui/widget.ts
+++ b/src/ui/widget.ts
@@ -81,16 +81,24 @@ function formatMonitorProgress(monitor: { progress?: { current?: number; total?:
 }
 
 function formatMonitorActivity(monitor: {
-  progress?: { current?: number; total?: number; message?: string };
+  progress?: { current?: number; total?: number; message?: string; updatedAt?: number };
   startedAt: number;
+  lastActivityAt?: number;
   lastOutputAt?: number;
   outputRatePerMinute?: number;
 }): string | undefined {
   const progress = monitor.progress ? formatMonitorProgress(monitor) : undefined;
-  const silence = Date.now() - (monitor.lastOutputAt ?? monitor.startedAt);
+  const now = Date.now();
+  const lastActivityAt = Math.max(
+    monitor.startedAt,
+    monitor.lastActivityAt ?? 0,
+    monitor.lastOutputAt ?? 0,
+    monitor.progress?.updatedAt ?? 0,
+  );
+  const silence = now - lastActivityAt;
   const activity = silence >= 60000
     ? `quiet ${Math.round(silence / 60000)}m`
-    : monitor.outputRatePerMinute !== undefined
+    : monitor.lastOutputAt !== undefined && now - monitor.lastOutputAt < 60000 && monitor.outputRatePerMinute !== undefined
       ? `${monitor.outputRatePerMinute} lines/min`
       : undefined;
   return [progress, activity].filter(Boolean).join(" · ") || undefined;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2226,7 +2226,7 @@ describe("monitor tool wrappers", () => {
 
     expect(sentCustomMessages).toHaveLength(1);
     expect((sentCustomMessages[0].message as { content: string }).content).toContain(
-      "Monitor #1 timed out",
+      "Monitor #1 became stale",
     );
   }, 10000);
 

--- a/test/monitor-manager.test.ts
+++ b/test/monitor-manager.test.ts
@@ -637,13 +637,87 @@ describe("MonitorManager", () => {
     expect(await manager.stop(entry.id)).toBe(false);
   });
 
-  it("auto-stops monitors on timeout", async () => {
+  it("auto-stops monitors after the inactivity timeout", async () => {
     vi.useFakeTimers();
     manager.create("sleep 60", "timeout test", 500);
     expect(manager.get("1")!.status).toBe("running");
 
     vi.advanceTimersByTime(600);
     expect(manager.get("1")!).toMatchObject({ status: "stopped", stopReason: "timeout" });
+    vi.useRealTimers();
+  });
+
+  it("renews the inactivity timeout when the process emits partial output", async () => {
+    vi.useFakeTimers();
+    const child = createMockChildProcess({ exitCode: null });
+    manager = new MonitorManager(pi, createSequentialSpawn(child));
+    const entry = manager.create("active command", "output heartbeat", 500);
+    const initialDeadline = manager.getProcess(entry.id)?.deadlineTimer;
+
+    await vi.advanceTimersByTimeAsync(400);
+    child.stderr?.emit("data", Buffer.from("still working"));
+    expect(manager.getProcess(entry.id)?.deadlineTimer).toBe(initialDeadline);
+    expect(manager.list()[0]?.lastActivityAt).toBe(Date.now());
+    await vi.advanceTimersByTimeAsync(400);
+    expect(manager.get(entry.id)?.status).toBe("running");
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(manager.get(entry.id)).toMatchObject({ status: "stopped", stopReason: "timeout" });
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ["forward", 24 * 60 * 60 * 1000],
+    ["backward", -24 * 60 * 60 * 1000],
+  ])("uses monotonic inactivity time across a %s wall-clock jump", async (_direction, jump) => {
+    vi.useFakeTimers();
+    const child = createMockChildProcess({ exitCode: null });
+    manager = new MonitorManager(pi, createSequentialSpawn(child));
+    const entry = manager.create("active command", "clock-safe timeout", 500);
+
+    await vi.advanceTimersByTimeAsync(200);
+    vi.setSystemTime(Date.now() + jump);
+    await vi.advanceTimersByTimeAsync(299);
+    expect(manager.get(entry.id)?.status).toBe("running");
+    await vi.advanceTimersByTimeAsync(1);
+    expect(manager.get(entry.id)).toMatchObject({ status: "stopped", stopReason: "timeout" });
+    vi.useRealTimers();
+  });
+
+  it("chunks inactivity checks above Node's maximum timer delay", () => {
+    const child = createMockChildProcess({ exitCode: null });
+    const timeoutSpy = vi.spyOn(global, "setTimeout");
+    manager = new MonitorManager(pi, createSequentialSpawn(child));
+
+    manager.create("very long command", "large inactivity timeout", 2_147_484_647);
+
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2_147_483_647);
+    child.emit("close", 0);
+    timeoutSpy.mockRestore();
+  });
+
+  it("rejects invalid inactivity timeouts before spawning", () => {
+    const spawn = vi.fn(createSequentialSpawn(createMockChildProcess({ exitCode: null })));
+    manager = new MonitorManager(pi, spawn);
+
+    expect(() => manager.create("bad timeout", undefined, -1)).toThrow(/timeout/i);
+    expect(() => manager.create("bad timeout", undefined, Number.POSITIVE_INFINITY)).toThrow(/timeout/i);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("renews the inactivity timeout when structured progress is updated", async () => {
+    vi.useFakeTimers();
+    const child = createMockChildProcess({ exitCode: null });
+    manager = new MonitorManager(pi, createSequentialSpawn(child));
+    const entry = manager.create("active command", "progress heartbeat", 500);
+
+    await vi.advanceTimersByTimeAsync(400);
+    manager.updateProgress(entry.id, { message: "still working" });
+    await vi.advanceTimersByTimeAsync(400);
+    expect(manager.get(entry.id)?.status).toBe("running");
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(manager.get(entry.id)).toMatchObject({ status: "stopped", stopReason: "timeout" });
     vi.useRealTimers();
   });
 
@@ -665,7 +739,7 @@ describe("MonitorManager", () => {
     expect(callback).toHaveBeenCalledTimes(1);
     expect(errors).toEqual([{
       monitorId: entry.id,
-      error: "Timed out after 500ms",
+      error: "No monitor activity for 500ms",
       outputLines: 0,
     }]);
     vi.useRealTimers();
@@ -695,7 +769,7 @@ describe("MonitorManager", () => {
       createSequentialSpawn(createMockChildProcess({ exitCode: 0 })),
     );
     const entry = manager.create("echo done", "retention test");
-    await vi.runAllTicks();
+    vi.runAllTicks();
 
     await vi.advanceTimersByTimeAsync(15 * 60 * 1000 - 1);
     expect(manager.get(entry.id)?.status).toBe("completed");

--- a/test/monitor-tools.test.ts
+++ b/test/monitor-tools.test.ts
@@ -60,14 +60,23 @@ describe("MonitorCreate", () => {
     const out = await h.text("MonitorCreate", { command: "npm test" });
     expect(out).toContain("Monitor #1 started");
     expect(out).toContain("monitor:output is rate-limited");
+    expect(out).toContain("Inactivity timeout: 300s");
     expect(h.manager.create).toHaveBeenCalledWith("npm test", undefined, undefined);
     expect(h.handleMonitorDoneLoop).toHaveBeenCalledWith(expect.objectContaining({
-      prompt: expect.stringContaining("Monitor #1 timed out"),
+      prompt: expect.stringContaining("Monitor #1 became stale"),
       trigger: expect.objectContaining({ type: "event", source: "monitor:timeout" }),
     }), "1");
     expect(h.toolMap.get("MonitorCreate")?.renderShell).not.toBe("self");
     expect(h.toolMap.get("MonitorCreate")?.renderCall).toBeTypeOf("function");
     expect(h.toolMap.get("MonitorCreate")?.renderResult).toBeTypeOf("function");
+  });
+
+  it("rejects negative inactivity timeouts", () => {
+    const h = setup();
+    const schema = h.toolMap.get("MonitorCreate")?.parameters;
+
+    expect(Check(schema as any, { command: "npm test", timeout: -1 })).toBe(false);
+    expect(Check(schema as any, { command: "npm test", timeout: 0 })).toBe(true);
   });
 
   it("renders monitor lifecycle results as visible compact rows", async () => {
@@ -238,6 +247,7 @@ describe("MonitorList", () => {
 
   it("shows quiet time without claiming the monitor has failed", async () => {
     const h = setup({ list: () => [makeMonitor({
+      startedAt: Date.now() - 120000,
       lastOutputAt: Date.now() - 120000,
       outputRatePerMinute: 24,
     })] });
@@ -249,6 +259,24 @@ describe("MonitorList", () => {
       startedAt: Date.now() - 120000,
     })] });
     expect(await h.text("MonitorList", {})).toContain("quiet 2m");
+  });
+
+  it("treats recent structured progress as monitor activity", async () => {
+    const h = setup({ list: () => [makeMonitor({
+      startedAt: Date.now() - 120000,
+      lastOutputAt: Date.now() - 120000,
+      progress: { message: "still working", source: "agent", updatedAt: Date.now() },
+    })] });
+    expect(await h.text("MonitorList", {})).not.toContain("quiet");
+  });
+
+  it("uses authoritative activity for partial output", async () => {
+    const h = setup({ list: () => [makeMonitor({
+      startedAt: Date.now() - 120000,
+      lastOutputAt: Date.now() - 120000,
+      lastActivityAt: Date.now(),
+    })] });
+    expect(await h.text("MonitorList", {})).not.toContain("quiet");
   });
 });
 

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -10,6 +10,7 @@ function createMockMonitorManager() {
     status: string;
     startedAt: number;
     outputLines: number;
+    lastActivityAt?: number;
     lastOutputAt?: number;
     outputRatePerMinute?: number;
     progress?: { current?: number; total?: number; message?: string; source?: string; updatedAt?: number };
@@ -106,6 +107,36 @@ describe("LoopWidget status rendering", () => {
 
     widget.update();
     expect(latestStatusCall()).toEqual(["loops", "▶ 1 monitor | 25% · quiet 2m"]);
+  });
+
+  it("treats recent structured progress as monitor activity", () => {
+    monitorManager._add({
+      id: "1",
+      command: "python train.py",
+      status: "running",
+      startedAt: Date.now() - 120000,
+      lastOutputAt: Date.now() - 120000,
+      outputLines: 42,
+      progress: { message: "still working", source: "agent", updatedAt: Date.now() },
+    });
+
+    widget.update();
+    expect(latestStatusCall()).toEqual(["loops", "▶ 1 monitor | still working"]);
+  });
+
+  it("uses authoritative activity for partial output", () => {
+    monitorManager._add({
+      id: "1",
+      command: "python train.py",
+      status: "running",
+      startedAt: Date.now() - 120000,
+      lastOutputAt: Date.now() - 120000,
+      lastActivityAt: Date.now(),
+      outputLines: 42,
+    });
+
+    widget.update();
+    expect(latestStatusCall()).toEqual(["loops", "▶ 1 monitor"]);
   });
 
   it("shows observed log velocity when a monitor has no structured progress", () => {


### PR DESCRIPTION
## Summary

- treat `timeout` as a renewable inactivity threshold instead of an absolute runtime cap
- renew on stdout/stderr bytes, JSONL progress, and `MonitorUpdate`
- use monotonic stale detection, chunk oversized timer delays, and reject invalid timeout values before spawn
- expose authoritative activity to `MonitorList` and the status widget, including partial output
- update model-facing copy and operator documentation
