### PR TITLE
docs: refresh shipped behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ A workflow is one dynamic `LoopEntry` with a version-1 named-state definition.
 
 ## Subagent orchestration contract
 
-A first-generation orchestration is one finite, session-file-backed `LoopEntry` batch.
+An orchestration is one finite, session-file-backed `LoopEntry` batch.
 
 - It accepts explicit independent work only; it never discovers TaskStore work or workflow executions.
 - Creation requires protocol-v2 `pi-subagents` and rejects memory/project/custom/off storage.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
 <h1 align="center">@trevonistrevon/pi-loop</h1>
-<h6 align="center">Scheduled and event-driven agent re-wakes for pi, with dynamic goals and background process monitoring.</h6>
+<h6 align="center">Durable agent loops, workflows, tasks, subagent orchestration, and background monitoring for Pi.</h6>
 </p>
 
 ## Install
@@ -54,6 +54,8 @@ OrchestrationGet id="1"
 - Optional `pi-tasks` integration and a native task fallback
 - Session-scoped, bounded async subagent orchestration through protocol-v2 `pi-subagents`
 - Session-isolated persistence and a compact TUI status line
+
+> **Research note:** These features are designed to benefit my research. The loop may drive this tool toward unexpected design choices, so treat those choices as experimental and review them before relying on them.
 
 ## Commands and tools
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -2,15 +2,16 @@
 
 ## Authority boundaries
 
-pi-loop has three independent authorities:
+pi-loop separates controller, standalone-task, worker-execution, and monitor authorities:
 
 | Domain | Authority | Storage |
 | --- | --- | --- |
-| Loops, workflows, and subagent orchestrations | `LoopStore` | `.pi/loops/*.json` |
+| Loop controllers, workflow state, and orchestration intent, evidence, and local capacity | `LoopStore` | `.pi/loops/*.json` |
 | Standalone native tasks | `TaskStore` or external `pi-tasks` | `.pi/tasks/*.json` or provider-owned |
+| Orchestration worker execution and global concurrency | protocol-v2 `pi-subagents` | provider-owned |
 | Running monitors | `MonitorManager` | process memory |
 
-Workflow state work is embedded in `LoopStore` as `WorkflowExecutionRecord`. It never appears in TaskStore, `/tasks`, task RPC, `TaskClaim`, or `TaskUpdate`. Standalone tasks never control workflow transitions. Finite orchestration work is also embedded in LoopStore; it never discovers or projects tasks or workflow executions.
+Workflow state work is embedded in `LoopStore` as `WorkflowExecutionRecord`. It never appears in TaskStore, `/tasks`, task RPC, `TaskClaim`, or `TaskUpdate`. Standalone tasks never control workflow transitions. Finite orchestration intent, dispatch reservations, local capacity, and evidence are embedded in LoopStore; they never discover or project tasks or workflow executions. `pi-subagents` owns worker execution and its global queue.
 
 Notification buffers and monitor process handles are memory-only. Orchestration wake intent is durable until delivery acknowledgement, but delivery remains at-least-once across a crash. Persisted controllers recover when Pi resumes; they do not execute while Pi is absent.
 
@@ -21,7 +22,7 @@ Notification buffers and monitor process handles are memory-only. Orchestration 
 - `src/store.ts`: loop/workflow/orchestration persistence and atomic mutations
 - `src/task-store.ts`: standalone native task persistence
 - `src/*-reducer.ts`: pure state transitions
-- `src/runtime/`: session, notification, backlog, task-provider, and monitor completion wiring
+- `src/runtime/`: session, notification, backlog, task-provider, orchestration, and monitor-completion wiring
 - `src/tools/`: model-facing tool registrations
 - `src/rpc/`: vendored cross-extension RPC contract
 - `src/ui/`: status widget and tool rendering
@@ -36,7 +37,7 @@ File-backed stores use PID locks, unique temporary snapshots, fsync, atomic rena
 - `session` (default): isolated by Pi session ID;
 - `project`: shared in the working directory.
 
-Project scope shares durable state but does not yet elect one scheduler owner across concurrent Pi runtimes. Workflow execution leases prevent duplicate phase work; they are separate from the planned project scheduler fence. Subagent orchestration rejects memory, project, disabled, and custom-path stores; its first protocol is default file-backed session scope only.
+Project scope shares durable state but does not yet elect one scheduler owner across concurrent Pi runtimes. Workflow execution leases prevent duplicate phase work; they are separate from the planned project scheduler fence. Subagent orchestration rejects memory, project, disabled, and custom-path stores; it supports only default file-backed session scope.
 
 ## Loop model
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -93,7 +93,7 @@ Description-declared prerequisites are followed through `TaskGet`; TaskStore has
 
 ## Live E2E
 
-Live tests are opt-in and run in isolated temporary project scope.
+Live tests are opt-in and run in isolated temporary workspaces. Stateful workflow and backlog scenarios use project scope; orchestration uses default file-backed session scope.
 
 ```bash
 PI_LOOP_LIVE_MODEL="openai-codex/gpt-5.6-sol:minimal" npm run test:e2e
@@ -119,6 +119,12 @@ Backlog scenario:
 PI_LOOP_LIVE_MODEL="openai-codex/gpt-5.6-sol:minimal" npm run test:e2e:backlog
 ```
 
+The backlog scenario requires this first-run sequence:
+
+```text
+TaskList → TaskGet → TaskClaim → write/edit → shell validation → TaskUpdate completed
+```
+
 Subagent orchestration scenario:
 
 ```bash
@@ -127,13 +133,7 @@ PI_LOOP_LIVE_SUBAGENTS_EXTENSION="$HOME/.pi/agent/npm/node_modules/@tintinweb/pi
 npm run test:e2e:orchestration
 ```
 
-It runs in a temporary session-scoped project, proves two isolated workers settle with durable consumed evidence, then creates and cancels an active worker. The extension path defaults to the standard user package location when `PI_LOOP_LIVE_SUBAGENTS_EXTENSION` is omitted.
-
-It requires this first-run sequence:
-
-```text
-TaskList → TaskGet → TaskClaim → write/edit → shell validation → TaskUpdate completed
-```
+It runs in a temporary workspace with default file-backed session scope, proves two isolated workers settle with durable consumed evidence, then creates and cancels an active worker. The extension path defaults to the standard user package location when `PI_LOOP_LIVE_SUBAGENTS_EXTENSION` is omitted.
 
 Without `PI_LOOP_LIVE_MODEL`, live scripts exit with `SKIP`. Reports are bounded JSON under `.artifacts/` and do not record credentials; claim IDs are redacted where applicable.
 

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -235,7 +235,9 @@ Workers bootstrap existing work, coalesce repeated create events, resume eligibl
 
 Monitor events:
 
+- `monitor:started`
 - `monitor:output`
+- `monitor:finished`
 - `monitor:done`
 - `monitor:error`
 
@@ -274,7 +276,9 @@ const { id, task } = await rpcCall(pi.events, TASKS_RPC.create, {
 | `tasks:rpc:pending` | `{}` | `{ pending }` |
 | `tasks:rpc:create` | `{ subject, description, metadata? }` | `{ id, task }` |
 | `tasks:rpc:clean` | `{}` | `{ pruned }` |
-| `tasks:rpc:update` | `{ id, status?, subject?, description? }` | `{ task }` |
+| `tasks:rpc:update` | `{ id, status?, subject?, description?, claimId? }` | `{ task }` |
+| `tasks:rpc:claim` | `{ id, ownerSessionId, ownerRuntimeId, leaseMs, claimId? }` | `{ task, claim, takenOver, renewed }` |
+| `tasks:rpc:heartbeat` | `{ id, claimId, leaseMs }` | `{ task }` |
 
 Requests include `requestId`; replies arrive on `<channel>:reply:<requestId>` as `{ success: true, data }` or `{ success: false, error }`.
 
@@ -296,6 +300,6 @@ Session files live under `.pi/loops/` and `.pi/tasks/`. Keep `session` as the no
 
 ## Status line and limits
 
-The TUI status line summarizes active loops, monitors, and native tasks. Use `LoopList`, `MonitorList`, and `/tasks` for detail. `LoopList` reports active-loop `age` as wall-clock time since creation, including pause and process downtime; paused loops omit the field. The status clears when no work is active.
+The TUI status line summarizes ordinary loops, workflows, orchestrations, running monitors, and native tasks. Use `LoopList`, `OrchestrationGet`, `MonitorList`, and `/tasks` for detail. `LoopList` reports active-loop `age` as wall-clock time since creation, including pause and process downtime; paused loops omit the field. The status clears when no work is active.
 
-The runtime allows at most 25 active loops and 25 running monitors.
+The runtime allows at most 25 active loops and 25 running monitors. Each orchestration batch allows up to 32 work items, 8 local workers, and 3 attempts per item.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@trevonistrevon/pi-loop",
   "version": "0.7.9",
-  "description": "A pi extension for cron/event-based agent re-wake loops and background process monitoring.",
+  "description": "A Pi extension for scheduled/event-driven re-wakes, durable workflows, subagent orchestration, tasks, and background monitoring.",
   "author": "trevonistrevon",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- add a README research note about experimental, research-driven design choices
- align authority and scope documentation with shipped workflow/orchestration behavior
- correct live E2E, task RPC, monitor event, TUI, and limit references
- refresh package and README feature summaries
