### PR TITLE
fix(routing): handle child stdin errors

### DIFF
--- a/test/controller-routing-child-io.test.ts
+++ b/test/controller-routing-child-io.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { sendRpcPrompt } from "./e2e/rpc-child-io.mjs";
+
+type ErrorListener = (cause: Error) => void;
+
+class FailingStdin {
+  destroyed = false;
+  writable = true;
+  private readonly listeners = new Set<ErrorListener>();
+
+  once(event: "error", listener: ErrorListener): void {
+    if (event === "error") this.listeners.add(listener);
+  }
+
+  off(event: "error", listener: ErrorListener): void {
+    if (event === "error") this.listeners.delete(listener);
+  }
+
+  write(_payload: string, callback?: (error?: Error) => void): boolean {
+    const error = new Error("write EPIPE");
+    for (const listener of this.listeners) {
+      this.listeners.delete(listener);
+      listener(error);
+    }
+    callback?.(error);
+    return false;
+  }
+}
+
+describe("routing harness child I/O", () => {
+  it("reports a stdin EPIPE once instead of throwing an unhandled error", () => {
+    const stdin = new FailingStdin();
+    const onError = vi.fn();
+
+    expect(() => sendRpcPrompt({ stdin }, "routing-test", "create tasks", onError)).not.toThrow();
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({ message: "write EPIPE" });
+  });
+
+  it("reports an already-closed stdin without attempting a write", () => {
+    const stdin = new FailingStdin();
+    stdin.destroyed = true;
+    const write = vi.spyOn(stdin, "write");
+    const onError = vi.fn();
+
+    sendRpcPrompt({ stdin }, "routing-test", "create tasks", onError);
+
+    expect(write).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({ message: "pi stdin is not writable" });
+  });
+});

--- a/test/e2e/controller-routing-conformance.mjs
+++ b/test/e2e/controller-routing-conformance.mjs
@@ -6,6 +6,7 @@ import { dirname, join, resolve } from "node:path";
 import process from "node:process";
 import { StringDecoder } from "node:string_decoder";
 import { fileURLToPath } from "node:url";
+import { sendRpcPrompt } from "./rpc-child-io.mjs";
 
 const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const configuredModels = process.env.PI_LOOP_LIVE_ROUTING_MODELS ?? process.env.PI_LOOP_LIVE_MODEL;
@@ -26,10 +27,6 @@ const CONTROLLER_TOOLS = new Set(["WorkflowCreate", "TaskCreate", "LoopCreate"])
 
 if (models.length === 0) throw new Error("No routing models were configured");
 if (scenarios.length === 0) throw new Error("No controller-routing scenarios matched PI_LOOP_LIVE_ROUTING_SCENARIOS");
-
-function send(child, id, message) {
-  child.stdin.write(`${JSON.stringify({ id, type: "prompt", message })}\n`);
-}
 
 function textResult(event) {
   return (event.result?.content ?? [])
@@ -185,6 +182,12 @@ async function runScenario(model, scenario) {
     stdio: ["pipe", "pipe", "pipe"],
   });
 
+  const reportChildFailure = (channel, cause) => {
+    const error = new Error(`pi ${channel} failed for ${scenario.id}: ${cause instanceof Error ? cause.message : String(cause)}`, { cause });
+    failure ??= error;
+    rejectSettled?.(failure);
+  };
+  child.once("error", (cause) => reportChildFailure("process", cause));
   child.stderr.on("data", (chunk) => {
     stderr = `${stderr}${chunk}`.slice(-24_000);
   });
@@ -251,7 +254,7 @@ async function runScenario(model, scenario) {
 
   try {
     await new Promise((resolveWait) => setTimeout(resolveWait, startupMs));
-    send(child, `routing-${scenario.id}`, scenario.prompt);
+    sendRpcPrompt(child, `routing-${scenario.id}`, scenario.prompt, (cause) => reportChildFailure("stdin", cause));
     await settled;
     return {
       ...evaluateScenario(scenario, toolCalls, toolResults, agentRuns, Date.now() - startedAt - startupMs),

--- a/test/e2e/rpc-child-io.mjs
+++ b/test/e2e/rpc-child-io.mjs
@@ -1,0 +1,25 @@
+export function sendRpcPrompt(child, id, message, onError) {
+  let reported = false;
+  const report = (cause) => {
+    if (reported) return;
+    reported = true;
+    onError(cause instanceof Error ? cause : new Error(String(cause)));
+  };
+  child.stdin.once("error", report);
+
+  if (!child.stdin.writable || child.stdin.destroyed) {
+    child.stdin.off("error", report);
+    report(new Error("pi stdin is not writable"));
+    return;
+  }
+
+  try {
+    child.stdin.write(`${JSON.stringify({ id, type: "prompt", message })}\n`, (error) => {
+      if (error) report(error);
+      else child.stdin.off("error", report);
+    });
+  } catch (cause) {
+    child.stdin.off("error", report);
+    report(cause);
+  }
+}


### PR DESCRIPTION
## Summary

- treat Copilot's PR #64 stdin/EPIPE finding as a true positive
- route child-process and stdin failures through the harness's controlled rejection/artifact path
- guard already-closed stdin and deduplicate stream-event/write-callback errors
- add deterministic regressions for EPIPE and pre-closed stdin

## Validation

- targeted RED: missing guarded writer caused the new regression suite to fail
- targeted GREEN: `npx vitest run test/controller-routing-child-io.test.ts`
- live subset: `bounded-recurring-loop` passed at 100% accuracy
- `npm run lint` (four established warnings only)
- `npm run typecheck`
- `npm test` (766 tests)
- `npm run build`
- `npm run test:package` (108 files)
- `npm audit --audit-level=moderate`
- `git diff --check`
