### PR TITLE
feat(workflow): add reissue_state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,8 @@ A workflow is one dynamic `LoopEntry` with a version-1 named-state definition.
 - `WorkflowTransition` validates the live owner, settles source work, records evidence, advances state, and creates destination work in one locked write.
 - Paused terminal outcomes require a typed blocker claim; trusted providers run outside the LoopStore lock, then the transition uses exact state/revision/execution CAS.
 - Machine observations never grant user authority. Rejected, stale, or contradicted claims are state-preserving; restart recovery is explicit resubmission, not a persisted proposal.
-- `WorkflowRevise` applies typed additive changes with definition/state/sequence CAS, immutable prior-definition history, and no scheduler or TaskStore effect.
-- Current materialized state content is immutable. Current outgoing edges and future state content may be revised.
+- `WorkflowRevise` applies typed definition changes with definition/state/sequence CAS and immutable prior-definition history; it never touches TaskStore.
+- Active instructions are never mutated in place. `reissue_state` cancels the prior execution into history, creates fresh current work under the still-valid lease, and wakes the replacement after the locked write; through an administrative pause it parks the replacement instead of waking it. Current outgoing edges and future state content remain directly revisable.
 - Transition CAS includes definition revision so transition/revision races fail closed in either order.
 - Terminal completed workflows are deleted; terminal paused workflows remain inspectable with bounded admission and pause provenance.
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -91,12 +91,13 @@ No pending claim or general evidence ledger is persisted. A confirmed transition
 
 - `add_state`
 - `revise_state` for non-current state content
+- `reissue_state` for explicit replacement of current instructions
 - `add_transition`
 - `redirect_transition` with `expectedTo`
 
-Revision is additive: no remove, rename, full replacement, or current-state content mutation. Added states must be reachable and rejoin prior or terminal work. Redirected routes must retain a path to their prior target.
+Graph revision is additive: no remove, rename, or full-definition replacement. Added states must be reachable and rejoin prior or terminal work. Redirected routes must retain a path to their prior target. `revise_state` still rejects the current state; callers must choose `reissue_state` explicitly rather than mutating instructions beneath an execution.
 
-Acceptance appends the prior definition, reason, actor, timestamp, and patch to immutable history, then increments `definitionRevision`. Current execution, lease, counters, and scheduler state remain unchanged. Persist actionable plan gaps, then continue through the revised transition and claim while work remains actionable; revision never creates standalone workflow tasks. Maximum definition size is 65,536 UTF-8 bytes and maximum revision count is 32.
+Acceptance appends the prior definition, reason, actor, timestamp, and patch to immutable history, then increments `definitionRevision`. Ordinary revisions preserve the current execution, lease, counters, and scheduler state. `reissue_state` is the bounded exception: it targets only the current nonterminal state. On an active controller it cancels any old execution into `executionHistory`, creates a fresh execution ID under the still-valid owner lease, resets state-entry/fire timing, keeps transition sequence and attempt count unchanged, then re-arms the active trigger and queues a fresh idle wake after persistence. Through an administrative pause it performs the same replacement atomically but leaves the controller paused with no trigger or wake, so `/loop` resume delivers only the fresh instruction. `controller_limit` and other non-administrative pauses reject reissue; semantic terminals reject revision entirely. Reissuing taskless work may create an unowned task execution that must be claimed. Reissued `maxAttempts` may equal but never undercut the current attempt; state-local fire limits apply to the reset fire count. The revision and fresh execution ID fence stale transition attempts. Revision never creates standalone workflow tasks. Maximum definition size is 65,536 UTF-8 bytes and maximum revision count is 32.
 
 Revision and transition race through the same LoopStore lock. Revision-first makes a stale transition fail its definition CAS; transition-first makes a stale revision fail state/sequence CAS.
 

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -121,7 +121,15 @@ WorkflowRevise id="1" expectedRevision=1 expectedState="investigate" expectedTra
 ]'
 ```
 
-`WorkflowRevise` stores the prior definition, reason, accepted changes, timestamp, and runtime actor as immutable history. It preserves current execution and lease state, changes only future work or current outgoing edges, and rejects stale revisions or transitions. It never creates standalone tasks. See the [reference](./REFERENCE.md#adaptive-revision) for operation and graph rules.
+`WorkflowRevise` stores the prior definition, reason, accepted changes, timestamp, and runtime actor as immutable history. Ordinary changes preserve current execution and lease state while changing future work or current outgoing edges. When the active prompt itself is stale, use the explicit `reissue_state` operation instead of leaving a note that future agents must ignore it:
+
+```text
+WorkflowRevise id="1" expectedRevision=2 expectedState="open-pr" expectedTransitionSeq=1 reason="Wait for the Brick work before pushing" changes='[
+  {"op":"reissue_state","stateId":"open-pr","prompt":"Wait until Brick is done; do not push yet.","task":{"subject":"Wait for Brick","description":"Hold the branch until the user confirms Brick is complete."}}
+]'
+```
+
+Reissue atomically cancels the superseded execution into history, creates fresh current work under the still-valid lease, resets state timing, and queues a fresh wake without fabricating a transition. An administrative pause can be reissued in place: the replacement waits paused, and `/loop` resume wakes only the fresh instruction. `controller_limit` and other non-administrative pauses reject reissue because resuming them does not renew the exhausted controller; semantic terminals cannot be revised. Taskless work that gains a task starts unowned and requires `WorkflowClaim`. Stale revision, state, sequence, lease, and execution authority fail closed. Workflow revision never creates standalone tasks. See the [reference](./REFERENCE.md#adaptive-revision) for operation and graph rules.
 
 A missing prerequisite, missing route, or exhausted route is a plan gap—not automatically a blocker. Persist an actionable recovery route with `WorkflowRevise`, then continue through the revised transition and claim while work remains actionable. Call `WorkflowTransition` only when an available declared outcome is supported by evidence; never fabricate one. Do not stop or move the controller to terminal `paused` merely to report progress. Environmental blockers require trusted admission. If user authority is required, report the exact decision needed; machine observations cannot authorize the transition.
 

--- a/src/loop-reducer.ts
+++ b/src/loop-reducer.ts
@@ -318,6 +318,25 @@ export function reduceLoopState(state: LoopReducerState, event: LoopReducerEvent
 
   if (event.type === "LOOP_WORKFLOW_REVISED") {
     if (!loop.workflow) return { state, effects: [] };
+    const currentWorkflowState = loop.workflow.definition.states[loop.workflow.currentState];
+    const reissuesCurrentState = event.payload.changes.some((change) => change.op === "reissue_state");
+    if (
+      loop.status === "paused"
+      && loop.pause?.kind !== "administrative"
+      && !currentWorkflowState?.terminal
+      && reissuesCurrentState
+    ) {
+      const message = "This paused workflow cannot replace current work; inspect its pause provenance before choosing a new controller.";
+      return {
+        state,
+        effects: [{
+          type: "WORKFLOW_REVISION_REJECTED",
+          entityType: "loop",
+          entityId: id,
+          payload: { error: message, failure: { code: "workflow_paused", message } },
+        }],
+      };
+    }
     const result = reviseWorkflowRun(loop.workflow, {
       expectedRevision: event.payload.expectedRevision,
       expectedState: event.payload.expectedState,

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -23,8 +23,10 @@ function revisionRecovery(code: WorkflowRevisionFailure["code"] | undefined): st
       return "The active runtime owns this phase; wait for handoff or inspect LoopList after its lease expires.";
     case "monitor_wait_active":
       return "Wait for the attached monitor to settle before revising the workflow.";
+    case "workflow_paused":
+      return "This pause cannot be bypassed by reissue; inspect its provenance and choose an explicit bounded recovery.";
     case "current_state_immutable":
-      return "Preserve current work; revise only future states or outgoing transitions.";
+      return "Use reissue_state to atomically replace active instructions, or revise only future states and outgoing transitions.";
     case "revision_limit_reached":
     case "terminal_workflow":
       return "This workflow no longer accepts revisions; inspect LoopList before choosing a new controller.";
@@ -298,10 +300,10 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
     label: "WorkflowRevise",
     renderCall: renderToolCall("Workflow", (args) => `revise · #${String(toolArg(args, "id") ?? "?")} · r${String(toolArg(args, "expectedRevision") ?? "?")}`),
     renderResult: renderToolResult,
-    description: "Revise a running workflow with typed additive changes while preserving current work and history.",
+    description: "Revise a workflow through typed CAS changes; reissue_state safely replaces active instructions.",
     promptGuidelines: [
       "Non-task WorkflowRevise needs no claim. Pass exact CAS; use WorkflowClaim only for unowned/expired task work.",
-      "Persist actionable plan gaps with WorkflowRevise, then continue through the normal transition/claim; add_state + redirect_transition inserts prerequisites. Never create standalone tasks for workflow work.",
+      "For stale current work use reissue_state; it histories old execution and wakes fresh work. For prerequisites use add_state + redirect_transition. Never park under ignored instructions. Never create standalone tasks.",
     ],
     parameters: Type.Object({
       id: Type.String({ description: "Workflow loop ID" }),
@@ -310,7 +312,7 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
       expectedTransitionSeq: Type.Integer({ description: "Transition sequence reported by LoopList", minimum: 0 }),
       reason: Type.String({ description: "Why this revision is required", minLength: 1, maxLength: 1000 }),
       changes: Type.Array(WorkflowRevisionChangeSchema, {
-        description: "Atomic typed changes: add_state, revise_state, add_transition, or redirect_transition",
+        description: "Typed atomic changes; reissue_state replaces current work",
         minItems: 1,
         maxItems: 64,
       }),
@@ -326,9 +328,11 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
       if (!result.applied || !result.entry || !result.summary) {
         const failure = result.failure;
         const reason = result.error ?? "unknown revision error";
-        const next = revisionRecovery(failure?.code);
-        const message = `Workflow #${params.id} was not revised\nCode: ${failure?.code ?? "unknown"}\nReason: ${reason}\nNext: ${next}`;
         const current = getStore().get(params.id);
+        const next = failure?.code === "workflow_paused" && current?.pause?.kind === "controller_limit"
+          ? "The controller fire cap is exhausted; inspect it and create a new bounded workflow if work must continue. Resuming does not renew the cap."
+          : revisionRecovery(failure?.code);
+        const message = `Workflow #${params.id} was not revised\nCode: ${failure?.code ?? "unknown"}\nReason: ${reason}\nNext: ${next}`;
         return textResult(message, current?.workflow
           ? workflowDisplayDetails({
               entry: current,
@@ -339,14 +343,21 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
             })
           : { kind: "workflow", action: "revise", tone: "error", summary: `Workflow #${params.id} revision rejected`, expanded: [`Reason: ${reason}`, `Next: ${next}`] });
       }
-      updateWidget();
       const summary = result.summary;
+      const reissued = summary.reissuedStates.length > 0;
+      if (reissued && result.entry.status === "active") {
+        getTriggerSystem().remove(result.entry.id);
+        getTriggerSystem().add(result.entry);
+        onDynamicLoopActivated?.(result.entry);
+      }
+      updateWidget();
       const lines = [
         `Workflow #${params.id} revised: revision ${params.expectedRevision} → ${result.entry.workflow?.definitionRevision}`,
         `Reason: ${params.reason.trim()}`,
       ];
       if (summary.addedStates.length > 0) lines.push(`Added states: ${summary.addedStates.join(", ")}`);
       if (summary.revisedStates.length > 0) lines.push(`Revised state work: ${summary.revisedStates.join(", ")}`);
+      if (summary.reissuedStates.length > 0) lines.push(`Reissued active state: ${summary.reissuedStates.join(", ")}`);
       if (summary.addedTransitions.length > 0) {
         lines.push(`Added edges: ${summary.addedTransitions.map((edge) => `${edge.from}.${edge.outcome} → ${edge.to}`).join("; ")}`);
       }
@@ -354,8 +365,21 @@ export function registerWorkflowTools(options: WorkflowToolsOptions): void {
         lines.push(`Redirected edges: ${summary.redirectedTransitions.map((edge) => `${edge.from}.${edge.outcome}: ${edge.fromTarget} → ${edge.to}`).join("; ")}`);
       }
       const execution = result.entry.workflow?.activeExecution;
-      lines.push(`Current execution preserved: ${result.entry.workflow?.currentState}${execution ? ` (${execution.id})` : ""}`);
-      lines.push("Next: complete the active work and transition through the revised outcome.");
+      if (reissued) {
+        lines.push(`Current execution replaced: ${result.entry.workflow?.currentState}${execution ? ` (${execution.id})` : " (taskless)"}`);
+        if (result.entry.status === "paused") {
+          lines.push(execution && !execution.lease
+            ? `Next: WorkflowClaim({ id: "${result.entry.id}" }), then resume through /loop to wake the fresh instruction.`
+            : "Next: resume through /loop to wake the fresh instruction; the superseded prompt will not run.");
+        } else {
+          lines.push(execution && !execution.lease
+            ? `Next: WorkflowClaim({ id: "${result.entry.id}" }), then follow the fresh instruction.`
+            : "Next: follow the fresh instruction; do not execute the superseded prompt.");
+        }
+      } else {
+        lines.push(`Current execution preserved: ${result.entry.workflow?.currentState}${execution ? ` (${execution.id})` : ""}`);
+        lines.push("Next: complete the active work and transition through the revised outcome.");
+      }
       return textResult(
         lines.join("\n"),
         workflowDisplayDetails({

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,6 +196,14 @@ export type WorkflowRevisionChange =
       maxAttempts?: number;
     }
   | {
+      op: "reissue_state";
+      stateId: string;
+      prompt: string;
+      task?: WorkflowTaskDefinition;
+      loop?: WorkflowStateLoopDefinition;
+      maxAttempts?: number;
+    }
+  | {
       op: "add_transition";
       from: string;
       outcome: string;
@@ -224,6 +232,7 @@ export type WorkflowRevisionFailureCode =
   | "revision_conflict"
   | "run_conflict"
   | "terminal_workflow"
+  | "workflow_paused"
   | "monitor_wait_active"
   | "revision_limit_reached"
   | "actor_required"

--- a/src/workflow-revision.ts
+++ b/src/workflow-revision.ts
@@ -2,6 +2,7 @@ import { Check } from "typebox/value";
 import type {
   WorkflowDefinition,
   WorkflowDefinitionRevision,
+  WorkflowExecutionRecord,
   WorkflowRevisionChange,
   WorkflowRevisionFailure,
   WorkflowRunState,
@@ -29,6 +30,7 @@ export interface AuthorizedWorkflowRevisionInput extends WorkflowRevisionInput {
 export interface WorkflowRevisionSummary {
   addedStates: string[];
   revisedStates: string[];
+  reissuedStates: string[];
   addedTransitions: Array<{ from: string; outcome: string; to: string }>;
   redirectedTransitions: Array<{ from: string; outcome: string; fromTarget: string; to: string }>;
 }
@@ -41,6 +43,7 @@ type RevisionRejection = Extract<WorkflowRevisionResult, { applied: false }>;
 
 type AddStateChange = Extract<WorkflowRevisionChange, { op: "add_state" }>;
 type ReviseStateChange = Extract<WorkflowRevisionChange, { op: "revise_state" }>;
+type ReissueStateChange = Extract<WorkflowRevisionChange, { op: "reissue_state" }>;
 type AddTransitionChange = Extract<WorkflowRevisionChange, { op: "add_transition" }>;
 type RedirectTransitionChange = Extract<WorkflowRevisionChange, { op: "redirect_transition" }>;
 
@@ -140,7 +143,7 @@ function validateChangeIdentity(
   stateChanges: Set<string>,
   edgeChanges: Set<string>,
 ): RevisionRejection | undefined {
-  if (change.op === "add_state" || change.op === "revise_state") {
+  if (change.op === "add_state" || change.op === "revise_state" || change.op === "reissue_state") {
     if (stateChanges.has(change.stateId)) {
       return rejected("invalid_patch", `Workflow revision changes state "${change.stateId}" more than once.`);
     }
@@ -201,6 +204,15 @@ function validateRevisedLimits(run: WorkflowRunState, change: ReviseStateChange)
   return undefined;
 }
 
+function validateReissueLimits(run: WorkflowRunState, change: ReissueStateChange): RevisionRejection | undefined {
+  if (change.maxAttempts !== undefined && change.maxAttempts < (run.attemptsByState[change.stateId] ?? 0)) {
+    return rejected("invalid_patch", `State "${change.stateId}" maxAttempts cannot be below its current attempt count.`, {
+      stateId: change.stateId,
+    });
+  }
+  return undefined;
+}
+
 function validateStateRevision(
   run: WorkflowRunState,
   state: WorkflowStateDefinition | undefined,
@@ -248,6 +260,34 @@ function reviseState(
   return undefined;
 }
 
+function reissueState(
+  run: WorkflowRunState,
+  definition: WorkflowDefinition,
+  change: ReissueStateChange,
+  summary: WorkflowRevisionSummary,
+): RevisionRejection | undefined {
+  if (change.stateId !== run.currentState) {
+    return rejected("state_conflict", `reissue_state must target active state "${run.currentState}", not "${change.stateId}".`, {
+      stateId: change.stateId,
+    });
+  }
+  const state = definition.states[change.stateId];
+  if (!state) return rejected("state_conflict", `Workflow state "${change.stateId}" does not exist.`, { stateId: change.stateId });
+  if (!state.task && run.activeExecution) {
+    return rejected("execution_missing", "Taskless active state has an unexpected workflow execution; repair the run before reissuing it.");
+  }
+  const limitError = validateReissueLimits(run, change);
+  if (limitError) return limitError;
+
+  const revised: WorkflowStateDefinition = { ...state, prompt: change.prompt };
+  if (change.task !== undefined) revised.task = structuredClone(change.task);
+  if (change.loop !== undefined) revised.loop = structuredClone(change.loop);
+  if (change.maxAttempts !== undefined) revised.maxAttempts = change.maxAttempts;
+  definition.states[change.stateId] = revised;
+  summary.reissuedStates.push(change.stateId);
+  return undefined;
+}
+
 function applyStateChanges(
   run: WorkflowRunState,
   definition: WorkflowDefinition,
@@ -262,6 +302,11 @@ function applyStateChanges(
   const revisions = changes.filter((change): change is ReviseStateChange => change.op === "revise_state");
   for (const change of revisions) {
     const error = reviseState(run, definition, change, summary);
+    if (error) return error;
+  }
+  const reissues = changes.filter((change): change is ReissueStateChange => change.op === "reissue_state");
+  for (const change of reissues) {
+    const error = reissueState(run, definition, change, summary);
     if (error) return error;
   }
   return undefined;
@@ -372,6 +417,46 @@ function validateGraph(
   return undefined;
 }
 
+function replaceCurrentExecution(
+  run: WorkflowRunState,
+  definition: WorkflowDefinition,
+  nextRevision: number,
+  reason: string,
+  at: number,
+): Pick<WorkflowRunState, "activeExecution" | "executionHistory" | "stateEnteredAt" | "stateFireCounts"> {
+  const prior = run.activeExecution;
+  const cancelled: WorkflowExecutionRecord | undefined = prior
+    ? {
+        ...prior,
+        status: "cancelled",
+        updatedAt: at,
+        settledAt: at,
+        evidence: `Reissued: ${reason}`,
+        lease: undefined,
+      }
+    : undefined;
+  const task = definition.states[run.currentState]?.task;
+  const activeExecution: WorkflowExecutionRecord | undefined = task
+    ? {
+        id: `${run.currentState}:${run.transitionSeq}:r${nextRevision}`,
+        stateId: run.currentState,
+        transitionSeq: run.transitionSeq,
+        subject: task.subject,
+        description: task.description,
+        status: "active",
+        createdAt: at,
+        updatedAt: at,
+        lease: prior?.lease ? structuredClone(prior.lease) : undefined,
+      }
+    : undefined;
+  return {
+    activeExecution,
+    executionHistory: cancelled ? [...(run.executionHistory ?? []), cancelled] : run.executionHistory,
+    stateEnteredAt: at,
+    stateFireCounts: { ...run.stateFireCounts, [run.currentState]: 0 },
+  };
+}
+
 export function reviseWorkflowRun(
   run: WorkflowRunState,
   input: AuthorizedWorkflowRevisionInput,
@@ -394,6 +479,7 @@ export function reviseWorkflowRun(
   const summary: WorkflowRevisionSummary = {
     addedStates: [],
     revisedStates: [],
+    reissuedStates: [],
     addedTransitions: [],
     redirectedTransitions: [],
   };
@@ -403,13 +489,20 @@ export function reviseWorkflowRun(
   if (edgeError) return edgeError;
   const graphError = validateGraph(run, definition, summary);
   if (graphError) return graphError;
-  if (JSON.stringify(definition) === JSON.stringify(run.definition)) return rejected("invalid_patch", "Workflow revision is a no-op.");
+  const reissued = summary.reissuedStates.length > 0;
+  if (!reissued && JSON.stringify(definition) === JSON.stringify(run.definition)) {
+    return rejected("invalid_patch", "Workflow revision is a no-op.");
+  }
 
   const currentRevision = run.definitionRevision ?? 1;
+  const replacement = reissued
+    ? replaceCurrentExecution(run, definition, currentRevision + 1, reason, at)
+    : {};
   return {
     applied: true,
     run: {
       ...run,
+      ...replacement,
       definition,
       definitionRevision: currentRevision + 1,
       revisionHistory: [

--- a/src/workflow-schema.ts
+++ b/src/workflow-schema.ts
@@ -41,6 +41,14 @@ export const WorkflowRevisionChangeSchema = Type.Union([
     maxAttempts: Type.Optional(Type.Integer({ minimum: 1 })),
   }),
   Type.Object({
+    op: Type.Literal("reissue_state"),
+    stateId: Type.String({ minLength: 1 }),
+    prompt: Type.String({ minLength: 1 }),
+    task: Type.Optional(WorkflowTaskSchema),
+    loop: Type.Optional(WorkflowLoopSchema),
+    maxAttempts: Type.Optional(Type.Integer({ minimum: 1 })),
+  }),
+  Type.Object({
     op: Type.Literal("add_transition"),
     from: Type.String({ minLength: 1 }),
     outcome: Type.String({ minLength: 1 }),

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -26,7 +26,7 @@ function clearTestLoopStore(sessionId: string): void {
 }
 
 describe("workflow runtime wiring", () => {
-  const sessionIds = ["workflow-cap-session", "workflow-task-session"];
+  const sessionIds = ["workflow-cap-session", "workflow-task-session", "workflow-reissue-session"];
   beforeEach(() => sessionIds.forEach(clearTestLoopStore));
   afterEach(() => sessionIds.forEach(clearTestLoopStore));
   it("pauses an immediately fired workflow state at its local fire cap with recovery guidance", async () => {
@@ -66,6 +66,78 @@ describe("workflow runtime wiring", () => {
     expect(wake?.message.content).toContain("has reached its fire cap; this workflow is paused and no next cadence is scheduled");
     expect(wake?.message.content).toContain("Otherwise add a bounded recovery state/route with WorkflowRevise, then transition and claim it");
     expect(wake?.message.content).not.toContain("leave the workflow active for its next cadence");
+  });
+
+  it("persists reissued work and delivers only the fresh workflow instruction", async () => {
+    const { pi, toolMap, extensionHandlers, sentMessages } = createMockPi();
+    extension(pi as any);
+    await flushAsync();
+
+    const ctx = {
+      ui: { setStatus: vi.fn(), setWidget: vi.fn() },
+      hasPendingMessages: () => false,
+      sessionManager: { getSessionId: () => "workflow-reissue-session" },
+    };
+    for (const handler of extensionHandlers.get("turn_start") ?? []) {
+      await handler(null, ctx);
+    }
+
+    const definition = JSON.stringify({
+      version: 1,
+      initialState: "open-pr",
+      states: {
+        "open-pr": {
+          prompt: "Push now and open the PR.",
+          task: { subject: "Open PR", description: "Push now." },
+          on: { opened: "complete" },
+        },
+        complete: { prompt: "Finished.", terminal: "completed" },
+      },
+    });
+    for (const handler of extensionHandlers.get("agent_start") ?? []) {
+      await handler(null, ctx);
+    }
+    await toolMap.get("WorkflowCreate")!.execute!("create", { goal: "Open the PR", definition });
+    await flushAsync();
+    expect(sentMessages).toHaveLength(0);
+
+    const revised = await toolMap.get("WorkflowRevise")!.execute!("reissue", {
+      id: "1",
+      expectedRevision: 1,
+      expectedState: "open-pr",
+      expectedTransitionSeq: 0,
+      reason: "Wait for Brick.",
+      changes: [{
+        op: "reissue_state",
+        stateId: "open-pr",
+        prompt: "Wait for Brick; do not push yet.",
+        task: { subject: "Wait for Brick", description: "Hold until the user confirms Brick is done." },
+      }],
+    });
+    expect(sentMessages).toHaveLength(0);
+    for (const handler of extensionHandlers.get("agent_end") ?? []) {
+      await handler(null, ctx);
+    }
+    await flushAsync();
+
+    expect(revised.content[0].text).toContain("Current execution replaced: open-pr (open-pr:0:r2)");
+    expect(sentMessages).toHaveLength(1);
+    const wake = sentMessages.find((item) => item.message.content.includes("Loop #1 fired (workflow)"));
+    expect(wake?.message.content).toContain("Definition revision: 2");
+    expect(wake?.message.content).toContain("State instructions: Wait for Brick; do not push yet.");
+    expect(wake?.message.content).toContain("Active workflow work: Wait for Brick (open-pr:0:r2)");
+    expect(wake?.message.content).not.toContain("State instructions: Push now and open the PR.");
+
+    const storePath = resolveLoopStorePath({ loopScope: "session" }, "workflow-reissue-session");
+    expect(storePath).toBeDefined();
+    const persisted = new LoopStore(storePath! as string).get("1");
+    expect(persisted?.workflow).toMatchObject({
+      definitionRevision: 2,
+      activeExecution: { id: "open-pr:0:r2", subject: "Wait for Brick" },
+      executionHistory: [{ id: "open-pr:0", status: "cancelled" }],
+    });
+    const taskPath = resolveTaskStorePath({ loopScope: "session" }, "workflow-reissue-session");
+    expect(new TaskStore(taskPath).list()).toEqual([]);
   });
 
   it("creates and completes task-bearing workflow work", async () => {

--- a/test/loop-tools.test.ts
+++ b/test/loop-tools.test.ts
@@ -688,9 +688,20 @@ describe("Workflow tools", () => {
     const listed = await h.text("LoopList", {});
     expect(listed).toContain("Pause cause: semantic_terminal");
     expect(listed).toContain("Admission: environmental · test:release.failed = true · test@1");
+
+    const reissue = await h.text("WorkflowRevise", {
+      id: "1",
+      expectedRevision: 1,
+      expectedState: "blocked",
+      expectedTransitionSeq: 1,
+      reason: "Do not reopen terminal work.",
+      changes: [{ op: "reissue_state", stateId: "blocked", prompt: "Changed." }],
+    });
+    expect(reissue).toContain("Code: terminal_workflow");
+    expect(reissue).not.toContain("Resume the workflow through /loop");
   });
 
-  it("exposes typed workflow revision changes without replacement or ownership fields", () => {
+  it("exposes typed workflow revision changes without raw replacement or ownership fields", () => {
     const revise = h.toolMap.get("WorkflowRevise") as any;
 
     expect(revise).toBeDefined();
@@ -704,10 +715,112 @@ describe("Workflow tools", () => {
     expect(revise.parameters.properties.definition).toBeUndefined();
     expect(revise.parameters.properties.actor).toBeUndefined();
     expect(revise.parameters.properties.claimId).toBeUndefined();
-    expect(revise.description).toContain("typed additive changes");
+    expect(revise.description).toContain("typed CAS changes");
+    expect(JSON.stringify(revise.parameters.properties.changes)).toContain("reissue_state");
     expect(revise.promptGuidelines.join("\n")).toContain("Non-task WorkflowRevise needs no claim");
     expect(revise.promptGuidelines.join("\n")).toContain("use WorkflowClaim only for unowned/expired task work");
     expect(revise.promptGuidelines.join("\n")).toContain("Never create standalone tasks");
+    expect(revise.promptGuidelines.join("\n")).toContain("Never park under ignored instructions");
+  });
+
+  it("routes attempted current-state mutation to explicit reissue", async () => {
+    await h.text("WorkflowCreate", { goal: "Fix the regression", definition: taskDefinition });
+
+    const out = await h.text("WorkflowRevise", {
+      id: "1",
+      expectedRevision: 1,
+      expectedState: "investigate",
+      expectedTransitionSeq: 0,
+      reason: "The current prompt is stale.",
+      changes: [{ op: "revise_state", stateId: "investigate", prompt: "Wait for Brick." }],
+    });
+
+    expect(out).toContain("Code: current_state_immutable");
+    expect(out).toContain("Use reissue_state to atomically replace active instructions");
+    expect(h.store.get("1")?.workflow?.definitionRevision).toBe(1);
+  });
+
+  it("reissues administrative pauses without waking, but rejects exhausted controllers", async () => {
+    await h.text("WorkflowCreate", { goal: "Fix the regression", definition: taskDefinition });
+    h.store.pause("1", "administrative", "Hold.");
+    h.triggerSystem.add.mockClear();
+    h.triggerSystem.remove.mockClear();
+    h.onDynamicLoopActivated.mockClear();
+
+    const out = await h.text("WorkflowRevise", {
+      id: "1",
+      expectedRevision: 1,
+      expectedState: "investigate",
+      expectedTransitionSeq: 0,
+      reason: "Replace paused instructions.",
+      changes: [{ op: "reissue_state", stateId: "investigate", prompt: "Changed." }],
+    });
+
+    expect(out).toContain("Reissued active state: investigate");
+    expect(out).toContain("resume through /loop to wake the fresh instruction");
+    expect(out).toContain("superseded prompt will not run");
+    expect(h.store.get("1")).toMatchObject({
+      status: "paused",
+      workflow: { definitionRevision: 2, activeExecution: { id: "investigate:0:r2" } },
+    });
+    expect(h.triggerSystem.add).not.toHaveBeenCalled();
+    expect(h.triggerSystem.remove).not.toHaveBeenCalled();
+    expect(h.onDynamicLoopActivated).not.toHaveBeenCalled();
+
+    h.store.resume("1");
+    h.store.pause("1", "controller_limit", "loop fire cap reached");
+    const capped = await h.text("WorkflowRevise", {
+      id: "1",
+      expectedRevision: 2,
+      expectedState: "investigate",
+      expectedTransitionSeq: 0,
+      reason: "Do not renew bounded work implicitly.",
+      changes: [{ op: "reissue_state", stateId: "investigate", prompt: "Changed again." }],
+    });
+    expect(capped).toContain("controller fire cap is exhausted");
+    expect(capped).toContain("Resuming does not renew the cap");
+    expect(capped).not.toContain("Resume the workflow through /loop");
+  });
+
+  it("reissues active instructions, histories stale work, and wakes the fresh execution", async () => {
+    await h.text("WorkflowCreate", { goal: "Fix the regression", definition: taskDefinition });
+    const original = structuredClone(h.store.get("1")?.workflow?.activeExecution);
+    h.triggerSystem.add.mockClear();
+    h.triggerSystem.remove.mockClear();
+    h.onDynamicLoopActivated.mockClear();
+
+    const out = await h.text("WorkflowRevise", {
+      id: "1",
+      expectedRevision: 1,
+      expectedState: "investigate",
+      expectedTransitionSeq: 0,
+      reason: "Wait for the upstream Brick change.",
+      changes: [{
+        op: "reissue_state",
+        stateId: "investigate",
+        prompt: "Wait for Brick; do not push.",
+        task: { subject: "Wait for Brick", description: "Hold until the user confirms Brick is done." },
+      }],
+    });
+
+    const entry = h.store.get("1");
+    expect(out).toContain("Reissued active state: investigate");
+    expect(out).toContain("Current execution replaced: investigate (investigate:0:r2)");
+    expect(out).toContain("do not execute the superseded prompt");
+    expect(entry?.workflow).toMatchObject({
+      definitionRevision: 2,
+      stateEnteredAt: expect.any(Number),
+      definition: { states: { investigate: { prompt: "Wait for Brick; do not push." } } },
+      activeExecution: {
+        id: "investigate:0:r2",
+        subject: "Wait for Brick",
+        lease: original?.lease,
+      },
+      executionHistory: [{ id: "investigate:0", status: "cancelled", lease: undefined }],
+    });
+    expect(h.triggerSystem.remove).toHaveBeenCalledWith("1");
+    expect(h.triggerSystem.add).toHaveBeenCalledWith(entry);
+    expect(h.onDynamicLoopActivated).toHaveBeenCalledWith(entry);
   });
 
   it("requires the current execution lease before revising and preserves it after claim", async () => {

--- a/test/property/workflow.property.test.ts
+++ b/test/property/workflow.property.test.ts
@@ -108,6 +108,71 @@ describe("workflow properties", () => {
     );
   });
 
+  it("reissues active work without changing transition or lease authority", () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.stringMatching(/^[A-Za-z][A-Za-z0-9 ._-]{0,40}$/).filter((prompt) => prompt.trim() !== ""),
+          { minLength: 1, maxLength: 10 },
+        ),
+        (prompts) => {
+          const actor = { sessionId: "property-session", runtimeId: "property-runtime" };
+          const taskDefinition: WorkflowDefinition = {
+            version: 1,
+            initialState: "work",
+            states: {
+              work: {
+                prompt: "Original.",
+                task: { subject: "Original", description: "Original work." },
+                on: { done: "complete" },
+              },
+              complete: { prompt: "Complete.", terminal: "completed" },
+            },
+          };
+          let run = createWorkflowRun(taskDefinition, 0, actor);
+
+          prompts.forEach((prompt, index) => {
+            const before = structuredClone(run);
+            const result = reviseWorkflowRun(run, {
+              expectedRevision: index + 1,
+              expectedState: "work",
+              expectedTransitionSeq: 0,
+              reason: `Reissue ${index + 1}`,
+              changes: [{
+                op: "reissue_state",
+                stateId: "work",
+                prompt,
+                task: { subject: `Work ${index + 1}`, description: prompt },
+              }],
+              actor,
+            }, index + 1);
+
+            expect(result.applied).toBe(true);
+            if (!result.applied) return;
+            expect(result.run).toMatchObject({
+              currentState: "work",
+              transitionSeq: 0,
+              definitionRevision: index + 2,
+              activeExecution: {
+                id: `work:0:r${index + 2}`,
+                lease: before.activeExecution?.lease,
+              },
+            });
+            expect(result.run.executionHistory).toHaveLength(index + 1);
+            expect(result.run.executionHistory?.at(-1)).toMatchObject({
+              id: before.activeExecution?.id,
+              status: "cancelled",
+              lease: undefined,
+            });
+            expect(run).toEqual(before);
+            run = result.run;
+          });
+        },
+      ),
+      propertyOptions(),
+    );
+  });
+
   it("never exceeds generated max-attempt limits", () => {
     fc.assert(
       fc.property(fc.integer({ min: 1, max: 50 }), fc.integer({ min: 0, max: 100 }), (limit, attempts) => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -801,6 +801,106 @@ describe("LoopStore (file-backed)", () => {
     });
   });
 
+  it("persists reissued instructions, cancelled work, and the replacement lease atomically", () => {
+    const actor = { sessionId: "session-a", runtimeId: "runtime-a" };
+    const store = new LoopStore(filePath);
+    const entry = store.create({ type: "dynamic" }, "Open the PR", {
+      recurring: true,
+      actor,
+      workflow: {
+        version: 1,
+        initialState: "open-pr",
+        states: {
+          "open-pr": {
+            prompt: "Push now.",
+            task: { subject: "Open PR", description: "Push now." },
+            on: { opened: "done" },
+          },
+          done: { prompt: "Done.", terminal: "completed" },
+        },
+      },
+    });
+    const lease = structuredClone(entry.workflow?.activeExecution?.lease);
+
+    expect(store.reviseWorkflow(entry.id, {
+      expectedRevision: 1,
+      expectedState: "open-pr",
+      expectedTransitionSeq: 0,
+      reason: "Wait for Brick.",
+      changes: [{
+        op: "reissue_state",
+        stateId: "open-pr",
+        prompt: "Wait for Brick; do not push.",
+        task: { subject: "Wait", description: "Wait for user confirmation." },
+      }],
+    }, actor)).toMatchObject({ applied: true, summary: { reissuedStates: ["open-pr"] } });
+    expect(store.transitionWorkflow(entry.id, { outcome: "opened", actor }, {
+      currentState: "open-pr",
+      transitionSeq: 0,
+      definitionRevision: 2,
+      activeExecutionId: "open-pr:0",
+    })).toMatchObject({ applied: false, error: expect.stringContaining("changed") });
+
+    const restarted = new LoopStore(filePath);
+    expect(restarted.get(entry.id)?.workflow).toMatchObject({
+      definitionRevision: 2,
+      definition: { states: { "open-pr": { prompt: "Wait for Brick; do not push." } } },
+      activeExecution: { id: "open-pr:0:r2", subject: "Wait", lease },
+      executionHistory: [{ id: "open-pr:0", status: "cancelled" }],
+      revisionHistory: [{ revision: 1, reason: "Wait for Brick." }],
+    });
+    expect(restarted.get(entry.id)?.workflow?.executionHistory?.[0]?.lease).toBeUndefined();
+  });
+
+  it("reissues through administrative pauses but rejects exhausted controllers", () => {
+    const actor = { sessionId: "session-a", runtimeId: "runtime-a" };
+    const store = new LoopStore(filePath);
+    const entry = store.create({ type: "dynamic" }, "Paused work", {
+      recurring: true,
+      actor,
+      workflow: {
+        version: 1,
+        initialState: "work",
+        states: {
+          work: {
+            prompt: "Work.",
+            task: { subject: "Work", description: "Do it." },
+            on: { done: "complete" },
+          },
+          complete: { prompt: "Complete.", terminal: "completed" },
+        },
+      },
+    });
+    store.pause(entry.id, "administrative", "Hold.");
+    const beforeBytes = readFileSync(filePath, "utf8");
+
+    expect(store.reviseWorkflow(entry.id, {
+      expectedRevision: 1,
+      expectedState: "work",
+      expectedTransitionSeq: 0,
+      reason: "Replace paused instructions.",
+      changes: [{ op: "reissue_state", stateId: "work", prompt: "Changed." }],
+    }, actor)).toMatchObject({ applied: true, summary: { reissuedStates: ["work"] } });
+    expect(store.get(entry.id)).toMatchObject({
+      status: "paused",
+      workflow: { definitionRevision: 2, activeExecution: { id: "work:0:r2" } },
+    });
+    expect(readFileSync(filePath, "utf8")).not.toBe(beforeBytes);
+
+    store.resume(entry.id);
+    store.pause(entry.id, "controller_limit", "loop fire cap reached");
+    const cappedBytes = readFileSync(filePath, "utf8");
+    expect(store.reviseWorkflow(entry.id, {
+      expectedRevision: 3,
+      expectedState: "work",
+      expectedTransitionSeq: 0,
+      reason: "Do not renew bounded work implicitly.",
+      changes: [{ op: "reissue_state", stateId: "work", prompt: "Changed again." }],
+    }, actor)).toMatchObject({ applied: false, failure: { code: "workflow_paused" } });
+    expect(store.get(entry.id)?.workflow?.definitionRevision).toBe(2);
+    expect(readFileSync(filePath, "utf8")).toBe(cappedBytes);
+  });
+
   it("does not arm a persisted legacy active terminal workflow after restart", () => {
     const store1 = new LoopStore(filePath);
     const workflow = store1.create({ type: "dynamic" }, "Finish", {

--- a/test/workflow-reducer.test.ts
+++ b/test/workflow-reducer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { WorkflowDefinition } from "../src/types.js";
+import type { WorkflowDefinition, WorkflowRevisionChange } from "../src/types.js";
 import { validateWorkflowDefinition } from "../src/workflow-definition.js";
 import { createWorkflowRun, transitionWorkflowRun } from "../src/workflow-reducer.js";
 import { MAX_WORKFLOW_REVISIONS, reviseWorkflowRun } from "../src/workflow-revision.js";
@@ -355,6 +355,203 @@ describe("workflow reducer", () => {
     taskDefinition.states.implement.prompt = "Mutated original";
     expect(result.run.revisionHistory[0].changes[0]).toMatchObject({ state: { prompt: "Validate." } });
     expect(result.run.revisionHistory[0].definition.states.implement.prompt).toBe("Implement.");
+  });
+
+  it("atomically reissues the active state with fresh instructions under the current lease", () => {
+    const actor = { sessionId: "session-a", runtimeId: "runtime-a" };
+    const taskDefinition: WorkflowDefinition = {
+      version: 1,
+      initialState: "open-pr",
+      states: {
+        "open-pr": {
+          prompt: "Push now and open the PR.",
+          task: { subject: "Open PR", description: "Push now and open the PR." },
+          on: { opened: "done" },
+        },
+        done: { prompt: "Report.", terminal: "completed" },
+      },
+    };
+    const run = createWorkflowRun(taskDefinition, 100, actor);
+    run.stateFireCounts["open-pr"] = 3;
+    const before = structuredClone(run);
+    const originalExecution = structuredClone(run.activeExecution);
+    const originalLease = structuredClone(run.activeExecution?.lease);
+    const changes: WorkflowRevisionChange[] = [{
+      op: "reissue_state",
+      stateId: "open-pr",
+      prompt: "Wait until the Brick work is done; do not push yet.",
+      task: { subject: "Wait for Brick", description: "Hold the branch until the user confirms Brick is done." },
+    }];
+
+    const result = reviseWorkflowRun(run, {
+      expectedRevision: 1,
+      expectedState: "open-pr",
+      expectedTransitionSeq: 0,
+      reason: "The user deferred the push until Brick work finishes.",
+      changes,
+      actor,
+    }, 200);
+    if (!result.applied) throw new Error(result.error);
+
+    expect(result.run).toMatchObject({
+      definitionRevision: 2,
+      currentState: "open-pr",
+      transitionSeq: 0,
+      stateEnteredAt: 200,
+      stateFireCounts: { "open-pr": 0 },
+      definition: {
+        states: {
+          "open-pr": {
+            prompt: "Wait until the Brick work is done; do not push yet.",
+            task: { subject: "Wait for Brick", description: "Hold the branch until the user confirms Brick is done." },
+          },
+        },
+      },
+      activeExecution: {
+        id: "open-pr:0:r2",
+        stateId: "open-pr",
+        transitionSeq: 0,
+        status: "active",
+        subject: "Wait for Brick",
+        description: "Hold the branch until the user confirms Brick is done.",
+        lease: originalLease,
+      },
+      executionHistory: [{
+        ...originalExecution,
+        status: "cancelled",
+        updatedAt: 200,
+        settledAt: 200,
+        evidence: "Reissued: The user deferred the push until Brick work finishes.",
+        lease: undefined,
+      }],
+    });
+    expect(result.run.revisionHistory[0]).toMatchObject({
+      revision: 1,
+      definition: taskDefinition,
+      changes,
+    });
+    expect(run).toEqual(before);
+  });
+
+  it("can reissue taskless current instructions into fresh unowned work", () => {
+    const actor = { sessionId: "session-a", runtimeId: "runtime-a" };
+    const taskless: WorkflowDefinition = {
+      version: 1,
+      initialState: "wait",
+      states: {
+        wait: { prompt: "Wait.", on: { ready: "done" } },
+        done: { prompt: "Done.", terminal: "completed" },
+      },
+    };
+    const run = createWorkflowRun(taskless, 100);
+    const result = reviseWorkflowRun(run, {
+      expectedRevision: 1,
+      expectedState: "wait",
+      expectedTransitionSeq: 0,
+      reason: "New work is now actionable.",
+      changes: [{
+        op: "reissue_state",
+        stateId: "wait",
+        prompt: "Implement the now-ready change.",
+        task: { subject: "Implement", description: "Apply the ready change." },
+      }],
+      actor,
+    }, 200);
+    if (!result.applied) throw new Error(result.error);
+
+    expect(result.summary.reissuedStates).toEqual(["wait"]);
+    expect(result.run).toMatchObject({
+      stateEnteredAt: 200,
+      transitionSeq: 0,
+      activeExecution: {
+        id: "wait:0:r2",
+        subject: "Implement",
+        lease: undefined,
+      },
+    });
+    expect(result.run.executionHistory).toBeUndefined();
+  });
+
+  it("validates reissue limits against reset fires and the unchanged current attempt", () => {
+    const actor = { sessionId: "session-a", runtimeId: "runtime-a" };
+    const limited: WorkflowDefinition = {
+      version: 1,
+      initialState: "wait",
+      states: {
+        wait: {
+          prompt: "Wait.",
+          loop: { schedule: "*/5 * * * *", maxFires: 10 },
+          on: { done: "complete" },
+          maxAttempts: 1,
+        },
+        complete: { prompt: "Complete.", terminal: "completed" },
+      },
+    };
+    const run = createWorkflowRun(limited, 100);
+    run.stateFireCounts.wait = 5;
+    const accepted = reviseWorkflowRun(run, {
+      expectedRevision: 1,
+      expectedState: "wait",
+      expectedTransitionSeq: 0,
+      reason: "Restart the current instruction window.",
+      changes: [{
+        op: "reissue_state",
+        stateId: "wait",
+        prompt: "Wait for new evidence.",
+        maxAttempts: 1,
+        loop: { schedule: "*/10 * * * *", maxFires: 3 },
+      }],
+      actor,
+    }, 200);
+    expect(accepted).toMatchObject({
+      applied: true,
+      run: { attemptsByState: { wait: 1 }, stateFireCounts: { wait: 0 } },
+    });
+
+    run.attemptsByState.wait = 2;
+    expect(reviseWorkflowRun(run, {
+      expectedRevision: 1,
+      expectedState: "wait",
+      expectedTransitionSeq: 0,
+      reason: "Do not erase attempt history.",
+      changes: [{ op: "reissue_state", stateId: "wait", prompt: "Changed.", maxAttempts: 1 }],
+      actor,
+    }, 200)).toMatchObject({ applied: false, failure: { code: "invalid_patch" } });
+  });
+
+  it("rejects reissuing a non-current state or combining two changes to active work", () => {
+    const actor = { sessionId: "session-a", runtimeId: "runtime-a" };
+    const taskDefinition: WorkflowDefinition = {
+      version: 1,
+      initialState: "work",
+      states: {
+        work: { prompt: "Work.", task: { subject: "Work", description: "Do it." }, on: { done: "future" } },
+        future: { prompt: "Future.", on: { done: "complete" } },
+        complete: { prompt: "Complete.", terminal: "completed" },
+      },
+    };
+    const run = createWorkflowRun(taskDefinition, 100, actor);
+    const before = structuredClone(run);
+    const base = {
+      expectedRevision: 1,
+      expectedState: "work",
+      expectedTransitionSeq: 0,
+      reason: "Replace instructions.",
+      actor,
+    };
+
+    expect(reviseWorkflowRun(run, {
+      ...base,
+      changes: [{ op: "reissue_state", stateId: "future", prompt: "Changed." }],
+    }, 200)).toMatchObject({ applied: false, failure: { code: "state_conflict" } });
+    expect(reviseWorkflowRun(run, {
+      ...base,
+      changes: [
+        { op: "reissue_state", stateId: "work", prompt: "Changed." },
+        { op: "revise_state", stateId: "work", prompt: "Changed twice." },
+      ],
+    }, 200)).toMatchObject({ applied: false, failure: { code: "invalid_patch" } });
+    expect(run).toEqual(before);
   });
 
   it("rejects stale, unauthorized, destructive, and disconnected revisions without mutation", () => {


### PR DESCRIPTION
## Summary
- add `reissue_state` as a typed `WorkflowRevise` change that atomically replaces stale current instructions
- cancel the superseded execution into `executionHistory`, create a fresh execution ID under the still-valid lease, and reset state timing
- fence stale transitions via the new execution ID and definition revision; re-arm the trigger and queue a fresh wake only after persisted success

## Semantics
- current task work requires a live owner lease; the lease is preserved onto the replacement execution
- taskless states that gain a task start unowned and require `WorkflowClaim`
- reissued `maxAttempts` may equal but never undercut the current attempt; state fire counts reset to zero
- administrative pauses reissue in place: the replacement waits paused with no trigger or wake until `/loop` resume
- `controller_limit` and monitor-wait pauses reject reissue (`workflow_paused`); semantic terminals reject revision (`terminal_workflow`)
- `revise_state` on the current state now explicitly routes callers to `reissue_state`
