### PR TITLE
fix(test): absorb scheduler jitter in hybrid cap test

### DIFF
--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -418,7 +418,12 @@ describe("CronScheduler", () => {
     });
     scheduler.add(entry);
 
-    vi.advanceTimersByTime(5 * 60 * 1000);
+    // Advance past one full cron step plus the worst-case per-ID jitter
+    // (computeJitter can add up to half the step); a single boundary + jitter
+    // must land inside the advance window regardless of the real start time.
+    // maxFires=1 retires the loop after the first fire, so a second boundary
+    // inside the window cannot fire.
+    vi.advanceTimersByTime(6 * 60 * 1000);
     scheduler.pump(Date.now());
 
     expect(store.get(entry.id)?.status).toBe("paused");


### PR DESCRIPTION
Fixes the Windows CI failure on master after #71 (run 33353268899): "pauses maxed hybrid backlog workers" expected paused, got active.

Root cause: `computeJitter` adds up to half the cron step (735ms for id "1" on `*/5`), so a 5-minute advance misses the single fire whenever the test starts within ~735ms after a wall-clock `*/5` boundary. Reproduced deterministically at clock 00:05:00.200 (fireTime 00:10:00.735 > advance end 00:10:00.200 → status active). Advancing 6 minutes always crosses boundary+jitter; `maxFires=1` retires the loop before any second boundary, so no double-fire. Test-only; no production change. Full suite verified locally (828 tests passed at 21:24). The local pre-push coverage hook hit the two documented flakes (session-store pollution, monitor shell-background timeout); both pass in isolation/clean state.