### PR TITLE
fix(store): publish lock ownership atomically

### DIFF
--- a/src/reducer-backed-store.ts
+++ b/src/reducer-backed-store.ts
@@ -47,7 +47,7 @@ function acquireLock(lockPath: string): LockOwner {
           try {
             const contents = readFileSync(lockPath, "utf-8");
             const match = /^(\d+)(?::[0-9a-f-]+)?$/.exec(contents);
-            if (contents.length > 0 && (!match || !isProcessRunning(Number(match[1])))) {
+            if (match && !isProcessRunning(Number(match[1]))) {
               try { unlinkSync(lockPath); } catch { /* another acquirer won stale cleanup */ }
               continue;
             }

--- a/src/reducer-backed-store.ts
+++ b/src/reducer-backed-store.ts
@@ -3,6 +3,7 @@ import {
   closeSync,
   existsSync,
   fsyncSync,
+  linkSync,
   mkdirSync,
   openSync,
   readFileSync,
@@ -24,33 +25,50 @@ export class StoreCorruptionError extends Error {
   }
 }
 
-function acquireLock(lockPath: string): void {
-  mkdirSync(dirname(lockPath), { recursive: true });
-  for (let i = 0; i < LOCK_MAX_RETRIES; i++) {
-    try {
-      writeFileSync(lockPath, `${process.pid}`, { flag: "wx" });
-      return;
-    } catch (e) {
-      if ((e as NodeJS.ErrnoException).code === "EEXIST") {
-        try {
-          const pid = parseInt(readFileSync(lockPath, "utf-8"), 10);
-          if (!pid || !isProcessRunning(pid)) {
-            try { unlinkSync(lockPath); } catch { /* ignore */ }
-            continue;
-          }
-        } catch { /* ignore read errors */ }
-        const start = Date.now();
-        while (Date.now() - start < LOCK_RETRY_MS) { /* busy wait */ }
-        continue;
-      }
-      throw e;
-    }
-  }
-  throw new Error(`Failed to acquire lock: ${lockPath}`);
+interface LockOwner {
+  contents: string;
 }
 
-function releaseLock(lockPath: string): void {
-  try { unlinkSync(lockPath); } catch { /* ignore */ }
+function acquireLock(lockPath: string): LockOwner {
+  mkdirSync(dirname(lockPath), { recursive: true });
+  const token = randomUUID();
+  const owner: LockOwner = { contents: `${process.pid}:${token}` };
+  const candidatePath = `${lockPath}.${token}.candidate`;
+  writeFileSync(candidatePath, owner.contents, { flag: "wx" });
+  try {
+    for (let i = 0; i < LOCK_MAX_RETRIES; i++) {
+      try {
+        // A hard link publishes the complete owner record atomically. Creating the
+        // final lock and filling it in separate syscalls leaves a stealable empty inode.
+        linkSync(candidatePath, lockPath);
+        return owner;
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code === "EEXIST") {
+          try {
+            const contents = readFileSync(lockPath, "utf-8");
+            const match = /^(\d+)(?::[0-9a-f-]+)?$/.exec(contents);
+            if (contents.length > 0 && (!match || !isProcessRunning(Number(match[1])))) {
+              try { unlinkSync(lockPath); } catch { /* another acquirer won stale cleanup */ }
+              continue;
+            }
+          } catch { /* unreadable or concurrently replaced locks stay fenced */ }
+          const start = Date.now();
+          while (Date.now() - start < LOCK_RETRY_MS) { /* busy wait */ }
+          continue;
+        }
+        throw e;
+      }
+    }
+    throw new Error(`Failed to acquire lock: ${lockPath}`);
+  } finally {
+    try { unlinkSync(candidatePath); } catch { /* linked lock retains the inode */ }
+  }
+}
+
+function releaseLock(lockPath: string, owner: LockOwner): void {
+  try {
+    if (readFileSync(lockPath, "utf-8") === owner.contents) unlinkSync(lockPath);
+  } catch { /* never remove a lock whose ownership cannot be confirmed */ }
 }
 
 function isProcessRunning(pid: number): boolean {
@@ -210,11 +228,11 @@ export abstract class ReducerBackedStore<
         this.recoverPrevious(error);
         return;
       }
-      acquireLock(this.lockPath);
+      const lockOwner = acquireLock(this.lockPath);
       try {
         this.load(true, true);
       } finally {
-        releaseLock(this.lockPath);
+        releaseLock(this.lockPath, lockOwner);
       }
     }
   }
@@ -235,14 +253,14 @@ export abstract class ReducerBackedStore<
 
   protected withLock<T>(fn: () => T, shouldSave: (result: T) => boolean = () => true): T {
     if (!this.lockPath) return fn();
-    acquireLock(this.lockPath);
+    const lockOwner = acquireLock(this.lockPath);
     try {
       this.load(true, true);
       const result = fn();
       if (shouldSave(result)) this.save();
       return result;
     } finally {
-      releaseLock(this.lockPath);
+      releaseLock(this.lockPath, lockOwner);
     }
   }
 

--- a/src/reducer-backed-store.ts
+++ b/src/reducer-backed-store.ts
@@ -46,8 +46,8 @@ function acquireLock(lockPath: string): LockOwner {
         if ((e as NodeJS.ErrnoException).code === "EEXIST") {
           try {
             const contents = readFileSync(lockPath, "utf-8");
-            const match = /^(\d+)(?::[0-9a-f-]+)?$/.exec(contents);
-            if (match && !isProcessRunning(Number(match[1]))) {
+            const pidPrefix = /^(\d+)/.exec(contents);
+            if (contents.length > 0 && (!pidPrefix || !isProcessRunning(Number(pidPrefix[1])))) {
               try { unlinkSync(lockPath); } catch { /* another acquirer won stale cleanup */ }
               continue;
             }

--- a/test/reducer-backed-store.test.ts
+++ b/test/reducer-backed-store.test.ts
@@ -136,6 +136,24 @@ describe("ReducerBackedStore", () => {
       }
     });
 
+    it("fails closed on malformed owner text with a live PID prefix", () => {
+      const path = join(dir, "items.json");
+      const a = new ItemStore(path);
+      a.set("x", 1);
+      const before = readFileSync(path, "utf8");
+      const lockPath = `${path}.lock`;
+      writeFileSync(lockPath, `${process.pid}:`);
+      let tick = 0;
+      const clock = vi.spyOn(Date, "now").mockImplementation(() => (tick += 100));
+      try {
+        expect(() => new ItemStore(path).set("x", 2)).toThrow(/lock/i);
+        expect(readFileSync(path, "utf8")).toBe(before);
+        expect(readFileSync(lockPath, "utf8")).toBe(`${process.pid}:`);
+      } finally {
+        clock.mockRestore();
+      }
+    });
+
     it("persists through withLock and reloads from disk", () => {
       const path = join(dir, "items.json");
       const a = new ItemStore(path);

--- a/test/reducer-backed-store.test.ts
+++ b/test/reducer-backed-store.test.ts
@@ -1,7 +1,7 @@
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, fstatSync, mkdtempSync, openSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AnyReducerEffect } from "../src/coordinator.js";
 import { ReducerBackedStore } from "../src/reducer-backed-store.js";
 
@@ -107,6 +107,33 @@ describe("ReducerBackedStore", () => {
     });
     afterEach(() => {
       rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("AUD-10: an empty live lock cannot be replaced or entered by a second writer", () => {
+      const path = join(dir, "items.json");
+      const a = new ItemStore(path);
+      a.set("x", 1);
+      const b = new ItemStore(path);
+      const before = readFileSync(path, "utf8");
+      const lockPath = `${path}.lock`;
+      // Hold A's exclusively created inode open before publishing its PID bytes.
+      const fd = openSync(lockPath, "wx");
+      const inode = fstatSync(fd).ino;
+      let tick = 0;
+      // Advance lock-retry accounting deterministically if acquisition fails closed.
+      const clock = vi.spyOn(Date, "now").mockImplementation(() => (tick += 100));
+      try {
+        expect.soft(() => b.set("x", 2)).toThrow(/lock/i);
+        expect.soft(b.seenEffects).toEqual([]);
+        expect.soft(b.get("x")).toEqual({ id: "x", value: 1 });
+        expect.soft(readFileSync(path, "utf8")).toBe(before);
+        expect.soft(existsSync(lockPath)).toBe(true);
+        expect.soft(existsSync(lockPath) ? statSync(lockPath).ino : undefined).toBe(inode);
+        expect.soft(fstatSync(fd).nlink).toBe(1);
+      } finally {
+        clock.mockRestore();
+        closeSync(fd);
+      }
     });
 
     it("persists through withLock and reloads from disk", () => {


### PR DESCRIPTION
## Summary
- publish complete lock ownership atomically
- prevent empty lock files from being stolen during initialization
- add deterministic persistence race coverage

## Validation
- focused persistence suite: 110 tests passed
- full branch suite: 905 tests passed

## Stack
1 of 6. Merge before the execution-identity authority PR.