### PR TITLE
fix(workflow): settle fire limits atomically

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -292,6 +292,10 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
       const record = settleExpiry ? this.expireEntryUnlocked(id, now) : undefined;
       return record ? { kind: "expired", record } : { kind: "ignored" };
     }
+    if (atMaxFires(entry) || (entry.workflow && atWorkflowStateFireLimit(entry.workflow))) {
+      this.settleFireLimitUnlocked(entry, now);
+      return { kind: "ignored" };
+    }
     this.applyReducerEvent({
       type: "LOOP_FIRED",
       at: now,
@@ -300,7 +304,39 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
       entityId: id,
       payload: { id, origin },
     });
-    return { kind: "fired", entry: this.entries.get(id)! };
+    const fired = this.entries.get(id)!;
+    const delivered = structuredClone(fired);
+    if (atMaxFires(fired) || (fired.workflow && atWorkflowStateFireLimit(fired.workflow))) {
+      this.settleFireLimitUnlocked(fired, now);
+    }
+    return { kind: "fired", entry: this.entries.get(id) ?? delivered };
+  }
+
+  private settleFireLimitUnlocked(entry: LoopEntry, at: number): void {
+    const workflowLimitReached = atMaxFires(entry);
+    if (!entry.workflow && !entry.taskBacklog) {
+      this.applyReducerEvent({
+        type: "LOOP_DELETED",
+        at,
+        source: "system",
+        entityType: "loop",
+        entityId: entry.id,
+        payload: { id: entry.id },
+      });
+      return;
+    }
+    this.applyReducerEvent({
+      type: "LOOP_PAUSED",
+      at,
+      source: "system",
+      entityType: "loop",
+      entityId: entry.id,
+      payload: {
+        id: entry.id,
+        kind: "controller_limit",
+        reason: workflowLimitReached ? "loop fire cap reached" : "workflow state fire cap reached",
+      },
+    });
   }
 
   fire(id: string, origin: LoopFireOrigin = "scheduler"): LoopEntry | undefined {

--- a/src/store.ts
+++ b/src/store.ts
@@ -305,11 +305,12 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
       payload: { id, origin },
     });
     const fired = this.entries.get(id)!;
-    const delivered = structuredClone(fired);
-    if (atMaxFires(fired) || (fired.workflow && atWorkflowStateFireLimit(fired.workflow))) {
-      this.settleFireLimitUnlocked(fired, now);
-    }
-    return { kind: "fired", entry: this.entries.get(id) ?? delivered };
+    const limitReached = atMaxFires(fired) || Boolean(fired.workflow && atWorkflowStateFireLimit(fired.workflow));
+    const deletedDelivery = limitReached && !fired.workflow && !fired.taskBacklog
+      ? structuredClone(fired)
+      : undefined;
+    if (limitReached) this.settleFireLimitUnlocked(fired, now);
+    return { kind: "fired", entry: this.entries.get(id) ?? deletedDelivery ?? fired };
   }
 
   private settleFireLimitUnlocked(entry: LoopEntry, at: number): void {

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -129,8 +129,22 @@ const WorkflowBlockerClaimSchema = Type.Object({
 });
 
 function workflowDefaultMaxFires(definition: WorkflowDefinition): number {
-  const loopBudget = Object.values(definition.states).reduce((total, state) => total + (state.loop?.maxFires ?? 0), 0);
-  return loopBudget > 0 ? loopBudget : 30;
+  let automaticFires = 0;
+  let hasCadence = false;
+  let hasUnboundedCadence = false;
+  for (const state of Object.values(definition.states)) {
+    if (state.terminal) continue;
+    if (state.loop) {
+      hasCadence = true;
+      if (state.loop.maxFires === undefined) hasUnboundedCadence = true;
+      else automaticFires += state.loop.maxFires;
+    } else {
+      automaticFires += state.maxAttempts ?? 1;
+    }
+  }
+  // Preserve the historical 30-wake allowance for ordinary-only workflows
+  // and unbounded cadence while reserving capacity for every activation.
+  return hasCadence ? Math.max(1, automaticFires + (hasUnboundedCadence ? 30 : 0)) : 30;
 }
 
 function stateLoopStartsImmediately(entry: LoopEntry): boolean {

--- a/test/astra-workflow-limits.test.ts
+++ b/test/astra-workflow-limits.test.ts
@@ -1,0 +1,80 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LoopStore } from "../src/store.js";
+
+describe("Astra workflow limit regressions", () => {
+  let dir: string;
+  let path: string;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    dir = mkdtempSync(join(tmpdir(), "pi-loop-astra-limits-"));
+    path = join(dir, "loops.json");
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.useRealTimers();
+  });
+
+  it.each(["workflow-wide", "state-local"] as const)("AUD-07: %s exhaustion rejects a second Store fire without a runtime pause", (limit) => {
+    const a = new LoopStore(path);
+    const entry = a.create({ type: "dynamic" }, "Poll release", {
+      recurring: true,
+      maxFires: limit === "workflow-wide" ? 1 : 10,
+      workflow: {
+        version: 1,
+        initialState: "poll",
+        states: {
+          poll: {
+            prompt: "Poll.",
+            ...(limit === "state-local" ? { loop: { schedule: "* * * * *", maxFires: 1 } } : {}),
+            on: { ready: "finish" },
+          },
+          finish: { prompt: "Finish.", on: { done: "done" } },
+          done: { prompt: "Done.", terminal: "completed" },
+        },
+      },
+    });
+    const b = new LoopStore(path);
+    expect(a.fire(entry.id)?.fireCount).toBe(1);
+    const before = readFileSync(path, "utf8");
+
+    expect.soft(b.fire(entry.id)).toBeUndefined();
+    expect.soft(new LoopStore(path).get(entry.id)?.fireCount).toBe(1);
+    expect.soft(readFileSync(path, "utf8")).toBe(before);
+  });
+
+  it.each(["workflow-wide", "state-local"] as const)("AUD-07: %s exhaustion rejects a nonterminal Store transition without a runtime pause", (limit) => {
+    const a = new LoopStore(path);
+    const entry = a.create({ type: "dynamic" }, "Poll release", {
+      recurring: true,
+      maxFires: limit === "workflow-wide" ? 1 : 10,
+      workflow: {
+        version: 1,
+        initialState: "poll",
+        states: {
+          poll: {
+            prompt: "Poll.",
+            ...(limit === "state-local" ? { loop: { schedule: "* * * * *", maxFires: 1 } } : {}),
+            on: { ready: "finish" },
+          },
+          finish: { prompt: "Finish.", on: { done: "done" } },
+          done: { prompt: "Done.", terminal: "completed" },
+        },
+      },
+    });
+    const b = new LoopStore(path);
+    expect(a.fire(entry.id)?.fireCount).toBe(1);
+    const before = readFileSync(path, "utf8");
+    const result = b.transitionWorkflow(entry.id, {
+      outcome: "ready",
+      ...(limit === "workflow-wide" ? { evidence: "Release is ready." } : {}),
+    }, { currentState: "poll", transitionSeq: 0, definitionRevision: 1 });
+
+    expect.soft(result.applied).toBe(false);
+    expect.soft(new LoopStore(path).get(entry.id)?.workflow).toMatchObject({ currentState: "poll", transitionSeq: 0 });
+    expect.soft(readFileSync(path, "utf8")).toBe(before);
+  });
+});

--- a/test/property/store.property.test.ts
+++ b/test/property/store.property.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import fc from "fast-check";
 import { describe, expect, it } from "vitest";
+import { LoopStore } from "../../src/store.js";
 import { TaskStore } from "../../src/task-store.js";
 import type { TaskStatus } from "../../src/task-types.js";
 import { propertyOptions } from "./config.js";
@@ -35,6 +36,54 @@ function normalizedTasks(store: TaskStore): ModelTask[] {
     status,
   }));
 }
+
+describe("workflow store properties", () => {
+  it("never persists more fires than the selected controller cap", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom("workflow-wide", "state-local"),
+        fc.integer({ min: 1, max: 8 }),
+        fc.integer({ min: 1, max: 16 }),
+        (limitKind, limit, attempts) => {
+          const directory = mkdtempSync(join(tmpdir(), "pi-loop-workflow-property-"));
+          const path = join(directory, "loops.json");
+          try {
+            const store = new LoopStore(path);
+            const entry = store.create({ type: "dynamic" }, "Poll", {
+              recurring: true,
+              maxFires: limitKind === "workflow-wide" ? limit : limit + attempts + 1,
+              workflow: {
+                version: 1,
+                initialState: "poll",
+                states: {
+                  poll: {
+                    prompt: "Poll.",
+                    loop: {
+                      schedule: "* * * * *",
+                      ...(limitKind === "state-local" ? { maxFires: limit } : {}),
+                    },
+                    on: { done: "done" },
+                  },
+                  done: { prompt: "Done.", terminal: "completed" },
+                },
+              },
+            });
+
+            for (let index = 0; index < attempts; index++) new LoopStore(path).fire(entry.id);
+
+            const persisted = new LoopStore(path).get(entry.id);
+            expect(persisted?.fireCount).toBe(Math.min(attempts, limit));
+            expect(persisted?.workflow?.stateFireCounts.poll).toBe(Math.min(attempts, limit));
+            expect(persisted?.status).toBe(attempts >= limit ? "paused" : "active");
+          } finally {
+            rmSync(directory, { recursive: true, force: true });
+          }
+        },
+      ),
+      propertyOptions(30, 100),
+    );
+  });
+});
 
 describe("task store properties", () => {
   it("preserves randomized command sequences across every reopen", () => {

--- a/test/workflow-task-integration.test.ts
+++ b/test/workflow-task-integration.test.ts
@@ -118,8 +118,42 @@ describe("embedded workflow execution integration", () => {
     for (const handler of harness.extensionHandlers.get("turn_start") ?? []) await handler(null, ctx);
     const taskPath = resolveTaskStorePath({ loopScope: "session", cwd }, sessionId)!;
     const loopPath = resolveLoopStorePath({ loopScope: "session", cwd }, sessionId)!;
-    return { ...harness, taskPath, loopPath };
+    return { ...harness, ctx, taskPath, loopPath };
   }
+
+  it("AUD-06: the default budget permits an ordinary phase followed by one cadence fire and completion", async () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const h = await setup();
+    try {
+      await h.emitExtension("agent_start", null, h.ctx);
+      const created = await h.toolMap.get("WorkflowCreate")!.execute!("create", {
+        goal: "Prepare and poll",
+        definition: JSON.stringify({
+          version: 1,
+          initialState: "prepare",
+          states: {
+            prepare: { prompt: "Prepare release.", on: { ready: "poll" } },
+            poll: { prompt: "Poll release.", loop: { schedule: "* * * * *", maxFires: 1 }, on: { done: "done" } },
+            done: { prompt: "Report success.", terminal: "completed" },
+          },
+        }),
+      });
+      expect(created.content[0].text).toContain("Workflow #1 created");
+      expect(new LoopStore(h.loopPath).get("1")?.fireCount).toBe(1);
+      const enteredPoll = await h.toolMap.get("WorkflowTransition")!.execute!("ready", { id: "1", outcome: "ready", evidence: "Preparation is complete." });
+      expect(enteredPoll.content[0].text).toContain("prepare → poll");
+      await h.emitExtension("agent_end", null, h.ctx);
+      // The 90s heartbeat crosses the minute boundary plus deterministic #1 jitter.
+      await vi.advanceTimersByTimeAsync(90_000);
+      expect(new LoopStore(h.loopPath).get("1")?.fireCount).toBe(2);
+      expect(h.sentMessages.filter((sent) => sent.message.content.includes("Poll release."))).toHaveLength(1);
+      const completed = await h.toolMap.get("WorkflowTransition")!.execute!("done", { id: "1", outcome: "done", evidence: "Release is ready." });
+      expect(completed.content[0].text).toContain("completed and deleted");
+      expect(new LoopStore(h.loopPath).get("1")).toBeUndefined();
+    } finally {
+      await h.emitExtension("session_shutdown", null, h.ctx);
+    }
+  });
 
   it("creates task-bearing workflow work before task-provider detection and leaves TaskStore empty", async () => {
     const h = await setup();


### PR DESCRIPTION
## Summary
- enforce workflow-wide and state-local fire limits under the Store lock
- preserve terminal settlement and evidenced exits without permitting renewal
- account for ordinary and cadence activation budgets
- add deterministic and property-based limit coverage

## Validation
- full branch suite: 919 tests passed

## Stack
3 of 6. Base: `fix/execution-identity-authority`.