### PR TITLE
fix(authority): fence controller lifecycle races

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,9 +148,13 @@ export default function (pi: ExtensionAPI) {
   async function maybeBootstrapTaskLoop(entry: LoopEntry): Promise<boolean> {
     if (!entry.recurring || !entry.taskBacklog) return false;
     if (!triggerHasEventSource(entry.trigger, "tasks:created")) return false;
+    const operationStore = store;
+    const operationGeneration = sessionGeneration;
 
     const pending = await hasPendingTasks();
-    if (pending <= 0) return false;
+    const current = operationStore.get(entry.id);
+    if (pending <= 0 || store !== operationStore || sessionGeneration !== operationGeneration
+      || current?.createdAt !== entry.createdAt) return false;
 
     debug(`loop #${entry.id} — bootstrapping existing pending tasks (${pending})`);
     onLoopFire(entry);
@@ -297,7 +301,7 @@ export default function (pi: ExtensionAPI) {
     if (retireIfExpired()) return;
     debug(`loop:fire #${entry.id}`, { prompt: entry.prompt.slice(0, 50) });
     const current = store.get(entry.id);
-    if (current?.status !== "active" || isTerminalWorkflowRun(current?.workflow)) {
+    if (current?.createdAt !== entry.createdAt || current.status !== "active" || isTerminalWorkflowRun(current.workflow)) {
       triggerSystem.remove(entry.id);
       return;
     }
@@ -346,16 +350,15 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
-    if (atMaxFires(firedEntry)) {
-      triggerSystem.remove(firedEntry.id);
-      if (firedEntry.workflow || firedEntry.taskBacklog) store.pause(firedEntry.id, "controller_limit", "loop fire cap reached");
-      else store.delete(firedEntry.id);
-      widget.update();
+    const postFireEntry = store.get(firedEntry.id);
+    if (firedEntry.workflow && postFireEntry?.workflow
+      && (postFireEntry.workflow.currentState !== firedEntry.workflow.currentState
+        || postFireEntry.workflow.transitionSeq !== firedEntry.workflow.transitionSeq
+        || postFireEntry.workflow.activeExecution?.id !== firedEntry.workflow.activeExecution?.id)) {
+      return;
     }
-
-    if (firedEntry.workflow && atWorkflowStateFireLimit(firedEntry.workflow)) {
+    if (postFireEntry?.status !== "active") {
       triggerSystem.remove(firedEntry.id);
-      store.pause(firedEntry.id, "controller_limit", "workflow state fire cap reached");
       widget.update();
     }
 
@@ -365,7 +368,7 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
-    if (current.autoTask) {
+    if (current.autoTask && !current.workflow) {
       taskProvider?.autoCreateTask(current).then((taskId) => {
         if (taskId) debug(`loop #${current.id} → task #${taskId}`);
       });

--- a/src/notification-reducer.ts
+++ b/src/notification-reducer.ts
@@ -8,6 +8,7 @@ export interface ReducerNotification {
   prompt: string;
   message: string;
   timestamp: number;
+  queueSequence: number;
   expiresAt?: number;
   controllerCreatedAt?: number;
   fireCount?: number;

--- a/src/runtime/notification-runtime.ts
+++ b/src/runtime/notification-runtime.ts
@@ -54,6 +54,7 @@ export interface LoopFireEvent {
 export interface PendingNotification extends LoopFireEvent {
   key: string;
   message: string;
+  queueSequence: number;
 }
 
 export interface MonitorStartedEvent {
@@ -94,6 +95,7 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
   };
   let flushPromise: Promise<void> | undefined;
   let sessionGeneration = 0;
+  let nextQueueSequence = 1;
 
   type NotificationDispatchResult = {
     kind: "delivery";
@@ -303,6 +305,7 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
     return {
       ...data,
       sessionGeneration: data.sessionGeneration ?? sessionGeneration,
+      queueSequence: nextQueueSequence++,
       key,
       message: buildLoopFireMessage(data),
     };
@@ -314,6 +317,7 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
     const isStaleEvent = data.reason === "resume_event_stale";
     return {
       sessionGeneration: data.sessionGeneration ?? sessionGeneration,
+      queueSequence: nextQueueSequence++,
       loopId: data.loopId,
       prompt: data.prompt,
       trigger: data.trigger,
@@ -337,6 +341,7 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
     const label = data.description ?? data.command.slice(0, 80);
     return {
       sessionGeneration: data.sessionGeneration ?? sessionGeneration,
+      queueSequence: nextQueueSequence++,
       loopId: `monitor:${data.monitorId}`,
       prompt: label,
       trigger: { type: "event", source: "monitor:started" },
@@ -353,7 +358,7 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
     const queued = notification.workflow;
     if (!queued || !getLoop || notification.controllerStatus === undefined) return notification;
     const current = getLoop(notification.loopId);
-    if (!current?.workflow || current.status !== notification.controllerStatus) return undefined;
+    if (!current?.workflow || current.status !== notification.controllerStatus || current.workflow.waitingMonitor) return undefined;
     if (current.workflow.currentState !== queued.currentState
       || current.workflow.transitionSeq !== queued.transitionSeq
       || current.workflow.activeExecution?.id !== queued.activeExecution?.id) return undefined;
@@ -421,7 +426,8 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
     }
     if (notificationState.agentRunning) {
       debug?.(`loop:fire #${notification.loopId} — runtime became busy before delivery, retaining wake`);
-      applyNotificationEvent({
+      const newer = notificationState.notificationsByKey[notification.key];
+      if (!newer || newer.queueSequence < notification.queueSequence) applyNotificationEvent({
         type: "NOTIFICATION_QUEUED",
         at: Date.now(),
         source: "system",

--- a/src/runtime/session-runtime.ts
+++ b/src/runtime/session-runtime.ts
@@ -243,12 +243,11 @@ export function registerSessionRuntimeHooks(options: SessionRuntimeOptions): voi
     stopHeartbeat();
     releaseTaskBacklogWakes();
     notificationRuntime.clear("session_shutdown");
-    await shutdownOrchestrations();
+    await Promise.all([shutdownMonitors(), shutdownOrchestrations()]);
     setSessionId(undefined);
     storeUpgraded = false;
     persistedShown = false;
     agentStartFireCounts = undefined;
-    await shutdownMonitors();
   });
 
   pi.on("session_switch" as never, async (event: SessionSwitchEvent, ctx: ExtensionContext) => {
@@ -258,11 +257,10 @@ export function registerSessionRuntimeHooks(options: SessionRuntimeOptions): voi
     stopHeartbeat();
     notificationRuntime.clear("session_switch");
     releaseTaskBacklogWakes();
-    await shutdownOrchestrations();
+    await Promise.all([shutdownMonitors(), shutdownOrchestrations()]);
     setSessionId(undefined);
     storeUpgraded = false;
     persistedShown = false;
-    await shutdownMonitors();
     if (!isCurrentGeneration(generation)) return;
 
     setLatestCtx(ctx);

--- a/src/store.ts
+++ b/src/store.ts
@@ -86,6 +86,9 @@ function normalizePauseRecord(entry: LoopEntry): LoopPauseRecord | undefined {
 
 function normalizeLoopEntry(entry: LoopEntry): LoopEntry {
   const pause = normalizePauseRecord(entry);
+  if (entry.workflow && (entry.autoTask || entry.taskBacklog || entry.orchestration)) {
+    throw new Error("Malformed loop controller: workflow cannot own standalone task or orchestration behavior");
+  }
   return {
     ...entry,
     ...(pause ? { pause } : {}),
@@ -176,6 +179,7 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
       }
       if (opts.workflow) {
         if (trigger.type !== "dynamic") throw new Error("Workflow loops require a dynamic trigger.");
+        if (opts.autoTask || opts.taskBacklog) throw new Error("Workflow controllers cannot create or adopt standalone tasks.");
         const validationError = validateWorkflowDefinition(opts.workflow);
         if (validationError) throw new Error(`Invalid workflow: ${validationError}`);
       }

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -138,6 +138,7 @@ function workflowDefaultMaxFires(definition: WorkflowDefinition): number {
       hasCadence = true;
       if (state.loop.maxFires === undefined) hasUnboundedCadence = true;
       else automaticFires += state.loop.maxFires;
+      if (state.loop.startImmediately) automaticFires += 1;
     } else {
       automaticFires += state.maxAttempts ?? 1;
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -59,9 +59,13 @@ describe("loop expiry runtime wiring", () => {
 });
 
 describe("workflow runtime wiring", () => {
-  const sessionIds = ["workflow-cap-session", "workflow-task-session", "workflow-reissue-session", "workflow-stale-wake-session"];
+  const sessionIds = ["workflow-cap-session", "workflow-cap-race-session", "workflow-task-session", "workflow-reissue-session", "workflow-stale-wake-session"];
   beforeEach(() => sessionIds.forEach(clearTestLoopStore));
-  afterEach(() => sessionIds.forEach(clearTestLoopStore));
+  afterEach(() => {
+    sessionIds.forEach(clearTestLoopStore);
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
   it("pauses an immediately fired workflow state at its local fire cap with recovery guidance", async () => {
     const { pi, toolMap, extensionHandlers, sentMessages } = createMockPi();
     extension(pi as any);
@@ -99,6 +103,62 @@ describe("workflow runtime wiring", () => {
     expect(wake?.message.content).toContain("has reached its fire cap; this workflow is paused and no next cadence is scheduled");
     expect(wake?.message.content).toContain("Otherwise add a bounded recovery state/route with WorkflowRevise, then transition and claim it");
     expect(wake?.message.content).not.toContain("leave the workflow active for its next cadence");
+  });
+
+  it("RA-02: stale capped-fire cleanup cannot re-pause an advanced destination", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const { pi, toolMap, extensionHandlers } = createMockPi();
+    extension(pi as any);
+    const sessionId = "workflow-cap-race-session";
+    const ctx = createCtx({ sessionId });
+    for (const handler of extensionHandlers.get("turn_start") ?? []) await handler(null, ctx);
+    const loopPath = resolveLoopStorePath({ loopScope: "session" }, sessionId)!;
+    const original = LoopStore.prototype.fireOrExpire;
+    let interposed = false;
+    vi.spyOn(LoopStore.prototype, "fireOrExpire").mockImplementation(function (...args) {
+      const result = original.apply(this, args);
+      if (!interposed && result.kind === "fired" && result.entry.workflow?.currentState === "poll") {
+        interposed = true;
+        const workflow = new LoopStore(loopPath).get(result.entry.id)!.workflow!;
+        expect(new LoopStore(loopPath).transitionWorkflow(result.entry.id, {
+          outcome: "ready",
+          evidence: "Poll passed concurrently.",
+        }, {
+          currentState: workflow.currentState,
+          transitionSeq: workflow.transitionSeq,
+          definitionRevision: workflow.definitionRevision,
+          activeExecutionId: workflow.activeExecution?.id,
+        }).applied).toBe(true);
+      }
+      return result;
+    });
+
+    await toolMap.get("WorkflowCreate")!.execute!("workflow-cap-race", {
+      goal: "Advance after capped poll",
+      maxFires: 10,
+      definition: JSON.stringify({
+        version: 1,
+        initialState: "poll",
+        states: {
+          poll: {
+            prompt: "Poll once.",
+            loop: { schedule: "* * * * *", maxFires: 1 },
+            on: { ready: "implement" },
+          },
+          implement: { prompt: "Implement.", on: { done: "done" } },
+          done: { prompt: "Done.", terminal: "completed" },
+        },
+      }),
+    });
+    await vi.advanceTimersByTimeAsync(90_000);
+
+    expect(interposed).toBe(true);
+    expect(new LoopStore(loopPath).get("1")).toMatchObject({
+      status: "active",
+      workflow: { currentState: "implement", transitionSeq: 1 },
+    });
+    vi.useRealTimers();
   });
 
   it("persists reissued work and delivers only the fresh workflow instruction", async () => {
@@ -1032,6 +1092,46 @@ describe("native task fallback", () => {
     const listResult = await taskList!.execute?.("3", {});
     expect(listResult.content[0].text).toContain("1 tasks (0 pending, 0 in progress, 1 done, 0 closed)");
     expect(listResult.content[0].text).toContain("#1 [completed] Done 1");
+  });
+
+  it("RA-05: delayed backlog bootstrap cannot fire a rebound same-id controller", async () => {
+    const h = createMockPi({ respondToTaskPing: true });
+    let pendingRequestId: string | undefined;
+    let lookupEntered!: () => void;
+    const entered = new Promise<void>((resolve) => { lookupEntered = resolve; });
+    h.pi.events.on("tasks:rpc:pending", (payload: { requestId?: string }) => {
+      pendingRequestId = payload.requestId;
+      lookupEntered();
+    });
+    extension(h.pi as any);
+    const ctxA = createCtx({ sessionId: "bootstrap-a" });
+    const ctxB = createCtx({ sessionId: "bootstrap-b" });
+    for (const handler of h.extensionHandlers.get("turn_start") ?? []) await handler(null, ctxA);
+    await vi.advanceTimersByTimeAsync(6100);
+
+    const pathB = resolveLoopStorePath({ loopScope: "session", cwd }, "bootstrap-b")!;
+    const unrelated = new LoopStore(pathB).create({ type: "cron", schedule: "0 0 1 1 *" }, "Unrelated B controller", {
+      recurring: true,
+      maxFires: 5,
+    });
+    const creating = h.toolMap.get("LoopCreate")!.execute!("create", {
+      trigger: "tasks:created",
+      prompt: "Adopt A backlog",
+      triggerType: "event",
+      recurring: true,
+      taskBacklog: true,
+      maxFires: 5,
+    });
+    await entered;
+    await h.emitExtension("session_switch", { reason: "switch" }, ctxB);
+    h.pi.events.emit(`tasks:rpc:pending:reply:${pendingRequestId}`, {
+      success: true,
+      data: { pending: 1 },
+    });
+    await creating;
+
+    expect(new LoopStore(pathB).get(unrelated.id)?.fireCount ?? 0).toBe(0);
+    expect(h.sentMessages.some((sent) => sent.message.content.includes("Unrelated B controller"))).toBe(false);
   });
 
   it("re-wakes an explicit task-backlog loop while unfinished work remains", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -93,7 +93,11 @@ describe("workflow runtime wiring", () => {
       },
     });
 
-    await toolMap.get("WorkflowCreate")!.execute!("workflow-local-cap", { goal: "Process records", definition });
+    await toolMap.get("WorkflowCreate")!.execute!("workflow-local-cap", {
+      goal: "Process records",
+      definition,
+      maxFires: 1,
+    });
     await flushAsync();
     const loops = await toolMap.get("LoopList")!.execute!("list-workflows", {});
     const wake = sentMessages.find((item) => item.message.content.includes("fired (workflow)"));

--- a/test/notification-coordinator.test.ts
+++ b/test/notification-coordinator.test.ts
@@ -14,6 +14,7 @@ function notification(overrides: Partial<ReducerNotification> = {}): ReducerNoti
     prompt: "hello",
     message: "hello",
     timestamp: 100,
+    queueSequence: 1,
     trigger: { type: "cron", schedule: "*/5 * * * *" },
     recurring: true,
     ...overrides,

--- a/test/notification-runtime.test.ts
+++ b/test/notification-runtime.test.ts
@@ -156,6 +156,87 @@ describe("notification runtime session boundary", () => {
     expect.soft(sentMessages[0]?.message.content).toContain("Adopt pending work");
   });
 
+  it("RA-04: busy retention preserves a newer same-key wake", async () => {
+    const { pi, sentMessages } = createMockPi();
+    let entered!: () => void;
+    let release!: () => void;
+    let first = true;
+    const lookupEntered = new Promise<void>((resolve) => { entered = resolve; });
+    const delayedLookup = new Promise<number>((resolve) => { release = () => resolve(1); });
+    const runtime = createNotificationRuntime({
+      pi,
+      hasPendingTasks: () => {
+        if (!first) return Promise.resolve(1);
+        first = false;
+        entered();
+        return delayedLookup;
+      },
+      cleanDoneTasks: async () => {},
+      getHasPendingMessages: () => false,
+    });
+    runtime.syncRuntimeState({ agentRunning: false, hasPendingMessages: false });
+    const oldWake = runtime.queueOrDeliverNotification({
+      loopId: "1", prompt: "Old instructions", trigger: { type: "cron", schedule: "* * * * *" },
+      timestamp: 1, autoTask: true, recurring: true,
+    });
+    await lookupEntered;
+    runtime.syncRuntimeState({ agentRunning: true });
+    const newWake = runtime.queueOrDeliverNotification({
+      loopId: "1", prompt: "New instructions", trigger: { type: "cron", schedule: "* * * * *" },
+      timestamp: 2, autoTask: true, recurring: true,
+    });
+    release();
+    await Promise.all([oldWake, newWake]);
+    runtime.syncRuntimeState({ agentRunning: false, hasPendingMessages: false });
+    await runtime.flushPendingNotifications({ ignorePendingMessages: true });
+
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0]?.message.content).toContain("New instructions");
+    expect(sentMessages[0]?.message.content).not.toContain("Old instructions");
+  });
+
+  it("RA-07: monitor attachment invalidates a buffered workflow wake", async () => {
+    const { pi, sentMessages } = createMockPi();
+    const store = new LoopStore();
+    const entry = store.create({ type: "dynamic" }, "Wait for monitor", {
+      recurring: true,
+      workflow: {
+        version: 1,
+        initialState: "wait",
+        states: {
+          wait: { prompt: "Do not run before the monitor.", on: { done: "done" } },
+          done: { prompt: "Done.", terminal: "completed" },
+        },
+      },
+    });
+    const runtime = createNotificationRuntime({
+      pi,
+      hasPendingTasks: async () => 0,
+      cleanDoneTasks: async () => {},
+      getHasPendingMessages: () => false,
+      getLoop: (id) => store.get(id),
+    });
+    runtime.syncRuntimeState({ agentRunning: true });
+    await runtime.queueOrDeliverNotification({
+      loopId: entry.id,
+      prompt: entry.prompt,
+      trigger: entry.trigger,
+      timestamp: entry.updatedAt,
+      recurring: true,
+      controllerStatus: entry.status,
+      workflow: entry.workflow,
+    });
+    expect(store.attachWorkflowMonitor(entry.id, "monitor-1", {
+      stateId: "wait",
+      transitionSeq: 0,
+      definitionRevision: 1,
+    })).toBeDefined();
+    runtime.syncRuntimeState({ agentRunning: false, hasPendingMessages: false });
+    await runtime.flushPendingNotifications({ ignorePendingMessages: true });
+
+    expect(sentMessages).toEqual([]);
+  });
+
   it("delivers an explicit recurring-loop expiry notification", async () => {
     const { pi, sentMessages } = createMockPi();
     const runtime = createNotificationRuntime({

--- a/test/session-runtime.test.ts
+++ b/test/session-runtime.test.ts
@@ -270,7 +270,26 @@ describe("session-runtime heartbeat lifecycle", () => {
 
     await drive("session_shutdown");
 
-    expect(calls).toEqual(["clear", "stop orchestration", "shutdown monitors"]);
+    expect(calls[0]).toBe("clear");
+    expect(new Set(calls.slice(1))).toEqual(new Set(["shutdown monitors", "stop orchestration"]));
+  });
+
+  it("RA-06: starts monitor shutdown before awaiting orchestration shutdown", async () => {
+    let releaseOrchestration!: () => void;
+    let enteredOrchestration!: () => void;
+    const orchestrationEntered = new Promise<void>((resolve) => { enteredOrchestration = resolve; });
+    const shutdownOrchestrations = vi.fn(() => new Promise<void>((resolve) => {
+      releaseOrchestration = resolve;
+      enteredOrchestration();
+    }));
+    const shutdownMonitors = vi.fn(async () => {});
+    const { drive } = setup({ shutdownOrchestrations, shutdownMonitors });
+
+    const shutdown = drive("session_shutdown");
+    await orchestrationEntered;
+    expect(shutdownMonitors).toHaveBeenCalledOnce();
+    releaseOrchestration();
+    await shutdown;
   });
 
   it("awaits monitor shutdown before completing session shutdown", async () => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -165,6 +165,23 @@ describe("LoopStore (in-memory)", () => {
     expect(store.get(created.id)?.status).toBe("paused");
   });
 
+  it.each(["autoTask", "taskBacklog"] as const)("RA-08: rejects workflow projection through %s", (flag) => {
+    const store = new LoopStore();
+    expect(() => store.create({ type: "dynamic" }, "Workflow", {
+      recurring: true,
+      [flag]: true,
+      workflow: {
+        version: 1,
+        initialState: "work",
+        states: {
+          work: { prompt: "Work.", on: { done: "done" } },
+          done: { prompt: "Done.", terminal: "completed" },
+        },
+      },
+    })).toThrow(/workflow.*standalone tasks/i);
+    expect(store.list()).toEqual([]);
+  });
+
   it("rejects a paused terminal transition without trusted admission", () => {
     store.create({ type: "dynamic" }, "Investigate", {
       recurring: true,

--- a/test/workflow-task-integration.test.ts
+++ b/test/workflow-task-integration.test.ts
@@ -189,6 +189,44 @@ describe("embedded workflow execution integration", () => {
     }
   });
 
+  it("RA-03: inferred budget reserves an extra fire for startImmediately cadence", async () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const h = await setup();
+    try {
+      await h.emitExtension("agent_start", null, h.ctx);
+      await h.toolMap.get("WorkflowCreate")!.execute!("create", {
+        goal: "Poll then finish",
+        definition: JSON.stringify({
+          version: 1,
+          initialState: "poll",
+          states: {
+            poll: {
+              prompt: "Poll release.",
+              loop: { schedule: "* * * * *", maxFires: 1, startImmediately: true },
+              on: { ready: "finish" },
+            },
+            finish: { prompt: "Finish release.", on: { done: "done" } },
+            done: { prompt: "Report success.", terminal: "completed" },
+          },
+        }),
+      });
+      expect(new LoopStore(h.loopPath).get("1")).toMatchObject({ maxFires: 3, fireCount: 1 });
+      await h.emitExtension("agent_end", null, h.ctx);
+      await vi.advanceTimersByTimeAsync(90_000);
+
+      const transitioned = await h.toolMap.get("WorkflowTransition")!.execute!("ready", {
+        id: "1", outcome: "ready", evidence: "Release is ready.",
+      });
+      expect(transitioned.content[0].text).toContain("poll → finish");
+      expect(new LoopStore(h.loopPath).get("1")).toMatchObject({
+        status: "active",
+        workflow: { currentState: "finish", transitionSeq: 1 },
+      });
+    } finally {
+      await h.emitExtension("session_shutdown", null, h.ctx);
+    }
+  });
+
   it("creates task-bearing workflow work before task-provider detection and leaves TaskStore empty", async () => {
     const h = await setup();
     const created = await h.toolMap.get("WorkflowCreate")!.execute!("create", {

--- a/test/workflow-task-integration.test.ts
+++ b/test/workflow-task-integration.test.ts
@@ -219,9 +219,15 @@ describe("embedded workflow execution integration", () => {
       });
       expect(transitioned.content[0].text).toContain("poll → finish");
       expect(new LoopStore(h.loopPath).get("1")).toMatchObject({
-        status: "active",
+        status: "paused",
+        fireCount: 3,
         workflow: { currentState: "finish", transitionSeq: 1 },
       });
+      const completed = await h.toolMap.get("WorkflowTransition")!.execute!("done", {
+        id: "1", outcome: "done", evidence: "Finish work completed.",
+      });
+      expect(completed.content[0].text).toContain("completed and deleted");
+      expect(new LoopStore(h.loopPath).get("1")).toBeUndefined();
     } finally {
       await h.emitExtension("session_shutdown", null, h.ctx);
     }


### PR DESCRIPTION
## Summary
- fence backlog bootstrap and monitor teardown across session rebinding
- prevent stale post-fire cleanup from mutating advanced workflow state
- reserve immediate cadence budget for controller activation
- reject workflow projection into standalone task behavior

## Validation
- full branch suite: 934 tests passed

## Stack
5 of 6. Base: `fix/notification-relevance`.