### PR TITLE
fix(authority): close controller boundary races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches: [master, main]
-  pull_request:
-    branches: [master, main]
+  pull_request: {}
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ See `docs/REFERENCE.md` for the public contract.
 
 Reducer-backed stores use:
 
-- `O_EXCL` PID locks with stale-owner detection;
+- initialized PID/UUID owner claims published by exclusive hard link, with sole-claim admission and stale-owner detection;
 - unique temporary snapshots;
 - file fsync, atomic rename, and directory fsync;
 - previous-snapshot recovery;

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -27,7 +27,7 @@ Notification buffers and monitor process handles are memory-only. Orchestration 
 - `src/rpc/`: vendored cross-extension RPC contract
 - `src/ui/`: status widget and tool rendering
 
-File-backed stores use PID locks, unique temporary snapshots, fsync, atomic rename, and previous-snapshot recovery. Corrupt state fails visibly when no valid snapshot exists.
+File-backed stores use PID locks, unique temporary snapshots, fsync, atomic snapshot rename, and previous-snapshot recovery. Lock publication never replaces a destination: an initialized PID/UUID owner file is hard-linked into directory scaffolding, and a writer enters only when its claim is the sole directory entry. Scaffolding alone grants no authority. Contenders withdraw only their own claims; recovery reclaims individually dead owner claims while live or unknown entries remain fences. Legacy file/directory owners stay supported. This protocol requires local-filesystem hard links and coherent directory enumeration; arbitrary network filesystems are not guaranteed. Corrupt state fails visibly when no valid snapshot exists.
 
 ## Scope
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -329,7 +329,17 @@ export default function (pi: ExtensionAPI) {
       widget.update();
       return;
     }
-    const fireResult = store.fireOrExpire(current.id, origin);
+    const fireResult = store.fireOrExpire(current.id, origin, undefined, {
+      createdAt: current.createdAt,
+      updatedAt: current.updatedAt,
+      status: current.status,
+      fireCount: current.fireCount ?? 0,
+      workflowState: current.workflow?.currentState,
+      workflowTransitionSeq: current.workflow?.transitionSeq,
+      workflowDefinitionRevision: current.workflow?.definitionRevision,
+      workflowExecutionId: current.workflow?.activeExecution?.id,
+      workflowMonitorId: current.workflow?.waitingMonitor?.monitorId,
+    });
     if (fireResult.kind === "expired") {
       emitLoopExpired(fireResult.record.entry, fireResult.record.disposition, expirySource, fireResult.record.reason);
       return;
@@ -350,13 +360,17 @@ export default function (pi: ExtensionAPI) {
         },
       }, fired.workflow ? {
         createdAt: fired.createdAt,
+        status: fired.status,
         currentState: fired.workflow.currentState,
         transitionSeq: fired.workflow.transitionSeq,
         definitionRevision: fired.workflow.definitionRevision,
         activeExecutionId: fired.workflow.activeExecution?.id,
       } : undefined);
-      if (!updatedEntry) return;
-      firedEntry = updatedEntry;
+      if (!updatedEntry) {
+        if (fireResult.settlement !== "deleted_by_fire_limit") return;
+      } else {
+        firedEntry = updatedEntry;
+      }
     }
     if (retireIfExpired()) {
       activeTaskBacklogWakes.delete(current.id);
@@ -373,6 +387,7 @@ export default function (pi: ExtensionAPI) {
     if (postFireEntry?.status !== "active") {
       triggerSystem.remove(firedEntry.id);
       widget.update();
+      if (postFireEntry && postFireEntry.pause?.kind !== "controller_limit") return;
     }
 
     if (Date.now() >= firedEntry.expiresAt) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,11 @@ export default function (pi: ExtensionAPI) {
     emitTaskBacklogEmpty: (payload) => {
       pi.events.emit("tasks:backlog_empty", payload);
     },
+    captureIsCurrent: () => {
+      const operationStore = store;
+      const operationGeneration = sessionGeneration;
+      return () => store === operationStore && sessionGeneration === operationGeneration;
+    },
     debug,
   });
 
@@ -335,16 +340,24 @@ export default function (pi: ExtensionAPI) {
 
     const firedAt = Date.now();
     const stateLoop = fired.workflow && getActiveWorkflowStateLoop(fired.workflow);
-    const updatedEntry = fired.trigger.type === "dynamic" && !stateLoop
-      ? store.updateDynamic(fired.id, {
-          dynamic: {
-            awaitingUpdate: true,
-            nextWakeAt: undefined,
-            lastUpdatedAt: firedAt,
-          },
-        }) ?? fired
-      : fired;
-    const firedEntry = updatedEntry;
+    let firedEntry = fired;
+    if (fired.trigger.type === "dynamic" && !stateLoop) {
+      const updatedEntry = store.updateDynamic(fired.id, {
+        dynamic: {
+          awaitingUpdate: true,
+          nextWakeAt: undefined,
+          lastUpdatedAt: firedAt,
+        },
+      }, fired.workflow ? {
+        createdAt: fired.createdAt,
+        currentState: fired.workflow.currentState,
+        transitionSeq: fired.workflow.transitionSeq,
+        definitionRevision: fired.workflow.definitionRevision,
+        activeExecutionId: fired.workflow.activeExecution?.id,
+      } : undefined);
+      if (!updatedEntry) return;
+      firedEntry = updatedEntry;
+    }
     if (retireIfExpired()) {
       activeTaskBacklogWakes.delete(current.id);
       return;
@@ -454,18 +467,7 @@ export default function (pi: ExtensionAPI) {
   // ── Loop fire handler — queues an in-memory notification, then injects a custom message when delivery is safe ──
 
   pi.events.on("loop:fire", async (event: unknown) => {
-    const data = event as LoopFireEvent;
-
-    if (data.autoTask) {
-      const pending = await hasPendingTasks();
-      if (pending === 0) {
-        debug(`loop:fire #${data.loopId} — no pending tasks, skipping, requesting cleanup`);
-        await cleanDoneTasks();
-        return;
-      }
-    }
-
-    await queueOrDeliverNotification(data);
+    await queueOrDeliverNotification(event as LoopFireEvent);
   });
 
   pi.events.on("monitor:started", async (event: unknown) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -402,10 +402,9 @@ export default function (pi: ExtensionAPI) {
       });
     }
 
-    const authoritativeEntry = store.get(firedEntry.id) ?? firedEntry;
     emitLoopFire({
-      ...authoritativeEntry,
-      prompt: promptOverride ?? authoritativeEntry.prompt,
+      ...firedEntry,
+      prompt: promptOverride ?? firedEntry.prompt,
     }, monitor);
   }
 

--- a/src/notification-reducer.ts
+++ b/src/notification-reducer.ts
@@ -109,8 +109,11 @@ export function reduceNotificationState(
   event: NotificationReducerEvent,
 ): NotificationReduceResult {
   if (event.type === "NOTIFICATION_QUEUED") {
+    const incoming = event.payload.notification;
+    const current = state.notificationsByKey[incoming.key];
+    if (current && current.queueSequence >= incoming.queueSequence) return { state, effects: [] };
     const next = cloneState(state);
-    next.notificationsByKey[event.payload.notification.key] = event.payload.notification;
+    next.notificationsByKey[incoming.key] = incoming;
     return {
       state: next,
       effects: [{ type: "REQUEST_NOTIFICATION_FLUSH", payload: {} }],

--- a/src/reducer-backed-store.ts
+++ b/src/reducer-backed-store.ts
@@ -30,6 +30,7 @@ export class StoreCorruptionError extends Error {
 
 interface LockOwner {
   contents: string;
+  ownerName: string;
 }
 
 function staleOwner(contents: string): boolean {
@@ -37,31 +38,22 @@ function staleOwner(contents: string): boolean {
   return pidPrefix ? !isProcessRunning(Number(pidPrefix[1])) : contents.length > 0;
 }
 
-function removeStaleDirectoryLock(lockPath: string, token: string): boolean {
-  const ownerPath = join(lockPath, "owner");
+function removeStaleDirectoryLock(lockPath: string): boolean {
   try {
-    const contents = readFileSync(ownerPath, "utf-8");
-    if (!staleOwner(contents)) return false;
-    const claimPath = join(lockPath, `.cleanup-${process.pid}-${token}`);
-    renameSync(ownerPath, claimPath);
-    unlinkSync(claimPath);
+    const names = readdirSync(lockPath);
+    if (names.length === 0) {
+      rmdirSync(lockPath);
+      return true;
+    }
+    if (names.length !== 1 || !names[0]?.startsWith("owner-")) return false;
+    const ownerPath = join(lockPath, names[0]);
+    if (!staleOwner(readFileSync(ownerPath, "utf-8"))) return false;
+    // The UUID-bearing owner name is the identity claim. A replacement
+    // directory cannot contain this exact pathname.
+    unlinkSync(ownerPath);
     try { rmdirSync(lockPath); } catch { /* a replacement non-empty directory stays fenced */ }
     return !existsSync(lockPath);
   } catch {
-    try {
-      const names = readdirSync(lockPath);
-      if (names.length === 0) {
-        rmdirSync(lockPath);
-        return true;
-      }
-      const cleanup = names.find((name) => /^\.cleanup-(\d+)-/.test(name));
-      const pid = cleanup ? Number(/^\.cleanup-(\d+)-/.exec(cleanup)?.[1]) : undefined;
-      if (cleanup && pid !== undefined && !isProcessRunning(pid)) {
-        unlinkSync(join(lockPath, cleanup));
-        rmdirSync(lockPath);
-        return true;
-      }
-    } catch { /* incomplete or concurrently replaced directories stay fenced */ }
     return false;
   }
 }
@@ -85,7 +77,7 @@ function removeStaleLegacyLock(lockPath: string, token: string): boolean {
 function removeStaleLock(lockPath: string, token: string): boolean {
   try {
     return statSync(lockPath).isDirectory()
-      ? removeStaleDirectoryLock(lockPath, token)
+      ? removeStaleDirectoryLock(lockPath)
       : removeStaleLegacyLock(lockPath, token);
   } catch {
     return false;
@@ -95,15 +87,18 @@ function removeStaleLock(lockPath: string, token: string): boolean {
 function acquireLock(lockPath: string): LockOwner {
   mkdirSync(dirname(lockPath), { recursive: true });
   const token = randomUUID();
-  const owner: LockOwner = { contents: `${process.pid}:${token}` };
+  const owner: LockOwner = {
+    contents: `${process.pid}:${token}`,
+    ownerName: `owner-${process.pid}-${token}`,
+  };
   const candidatePath = `${lockPath}.${token}.candidate`;
   mkdirSync(candidatePath);
-  writeFileSync(join(candidatePath, "owner"), owner.contents, { flag: "wx" });
+  writeFileSync(join(candidatePath, owner.ownerName), owner.contents, { flag: "wx" });
   try {
     for (let i = 0; i < LOCK_MAX_RETRIES; i++) {
       try {
         // Renaming a complete non-empty directory publishes ownership atomically.
-        // Stale cleanup claims its fixed owner entry before removing the directory.
+        // Unique owner names make stale cleanup conditional on the inspected identity.
         renameSync(candidatePath, lockPath);
         return owner;
       } catch (error) {
@@ -125,7 +120,7 @@ function acquireLock(lockPath: string): LockOwner {
 
 function releaseLock(lockPath: string, owner: LockOwner): void {
   try {
-    const ownerPath = join(lockPath, "owner");
+    const ownerPath = join(lockPath, owner.ownerName);
     if (readFileSync(ownerPath, "utf-8") !== owner.contents) return;
     unlinkSync(ownerPath);
     try { rmdirSync(lockPath); } catch { /* never remove a replacement owner's directory */ }

--- a/src/reducer-backed-store.ts
+++ b/src/reducer-backed-store.ts
@@ -85,7 +85,20 @@ function removeStaleDirectoryLock(lockPath: string, token: string): boolean {
     if (names.includes("owner") && abandonedUpgrade) {
       unlinkSync(join(lockPath, abandonedUpgrade));
     }
-    return false;
+    // Contenders may die together before either observes exclusive ownership.
+    // Reclaim only dead UUID claims; live and unknown entries remain fences.
+    let removed = false;
+    for (const name of names) {
+      if (!name.startsWith("owner-")) continue;
+      const ownerPath = join(lockPath, name);
+      if (!staleOwner(readFileSync(ownerPath, "utf-8"))) continue;
+      unlinkSync(ownerPath);
+      removed = true;
+    }
+    if (removed) {
+      try { rmdirSync(lockPath); } catch { /* remaining claims still fence the directory */ }
+    }
+    return removed;
   } catch {
     return false;
   }
@@ -117,6 +130,27 @@ function removeStaleLock(lockPath: string, token: string): boolean {
   }
 }
 
+function publishOwnerClaim(lockPath: string, candidatePath: string, owner: LockOwner): boolean {
+  const ownerPath = join(lockPath, owner.ownerName);
+  let exclusive = false;
+  try {
+    try { mkdirSync(lockPath); } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+    // Scaffolding grants no authority. The hard link exposes initialized bytes
+    // without replacing any existing path, including Windows legacy file locks.
+    linkSync(join(candidatePath, owner.ownerName), ownerPath);
+    const names = readdirSync(lockPath);
+    exclusive = names.length === 1 && names[0] === owner.ownerName;
+    return exclusive;
+  } finally {
+    // A live admitted owner always remains visible to subsequent contenders.
+    if (!exclusive) {
+      try { unlinkSync(ownerPath); } catch { /* this UUID claim was not published */ }
+    }
+  }
+}
+
 function acquireLock(lockPath: string): LockOwner {
   mkdirSync(dirname(lockPath), { recursive: true });
   const token = randomUUID();
@@ -130,24 +164,21 @@ function acquireLock(lockPath: string): LockOwner {
   try {
     for (let i = 0; i < LOCK_MAX_RETRIES; i++) {
       try {
-        // Renaming a complete non-empty directory publishes ownership atomically.
-        // Unique owner names make stale cleanup conditional on the inspected identity.
-        renameSync(candidatePath, lockPath);
-        return owner;
+        if (publishOwnerClaim(lockPath, candidatePath, owner)) return owner;
       } catch (error) {
         const code = (error as NodeJS.ErrnoException).code;
-        if (code === "EEXIST" || code === "ENOTDIR" || code === "ENOTEMPTY" || code === "EPERM" || code === "EACCES") {
-          if (removeStaleLock(lockPath, token)) continue;
-          const start = Date.now();
-          while (Date.now() - start < LOCK_RETRY_MS) { /* busy wait */ }
-          continue;
-        }
-        throw error;
+        // APFS can report EINVAL, rather than ENOENT, when another contender
+        // removes empty scaffolding while linkSync resolves its destination.
+        const vanishedScaffolding = code === "EINVAL" && (error as NodeJS.ErrnoException).syscall === "link";
+        if (!vanishedScaffolding && code !== "EEXIST" && code !== "ENOTDIR" && code !== "ENOENT" && code !== "ENOTEMPTY" && code !== "EPERM" && code !== "EACCES") throw error;
       }
+      if (removeStaleLock(lockPath, token)) continue;
+      const start = Date.now();
+      while (Date.now() - start < LOCK_RETRY_MS) { /* busy wait */ }
     }
     throw new Error(`Failed to acquire lock: ${lockPath}`);
   } finally {
-    try { rmSync(candidatePath, { recursive: true, force: true }); } catch { /* published candidate was renamed */ }
+    try { rmSync(candidatePath, { recursive: true, force: true }); } catch { /* private candidate cleanup is best effort */ }
   }
 }
 

--- a/src/reducer-backed-store.ts
+++ b/src/reducer-backed-store.ts
@@ -38,21 +38,54 @@ function staleOwner(contents: string): boolean {
   return pidPrefix ? !isProcessRunning(Number(pidPrefix[1])) : contents.length > 0;
 }
 
-function removeStaleDirectoryLock(lockPath: string): boolean {
+function removeStaleDirectoryLock(lockPath: string, token: string): boolean {
   try {
     const names = readdirSync(lockPath);
     if (names.length === 0) {
       rmdirSync(lockPath);
       return true;
     }
-    if (names.length !== 1 || !names[0]?.startsWith("owner-")) return false;
-    const ownerPath = join(lockPath, names[0]);
-    if (!staleOwner(readFileSync(ownerPath, "utf-8"))) return false;
-    // The UUID-bearing owner name is the identity claim. A replacement
-    // directory cannot contain this exact pathname.
-    unlinkSync(ownerPath);
-    try { rmdirSync(lockPath); } catch { /* a replacement non-empty directory stays fenced */ }
-    return !existsSync(lockPath);
+    if (names.length === 1 && names[0] === "owner") {
+      const ownerPath = join(lockPath, "owner");
+      const upgradePath = join(lockPath, `.upgrade-${process.pid}-${token}`);
+      try {
+        // Keep the predecessor directory non-empty while inspecting a hard link
+        // to its exact owner inode, so no replacement can be published beneath us.
+        linkSync(ownerPath, upgradePath);
+        if (!staleOwner(readFileSync(upgradePath, "utf-8"))) return false;
+        try { unlinkSync(ownerPath); } catch { return false; }
+      } finally {
+        try { unlinkSync(upgradePath); } catch { /* no upgrade claim was published */ }
+      }
+      try { rmdirSync(lockPath); } catch { /* another identity claim still fences the directory */ }
+      return !existsSync(lockPath);
+    }
+    if (names.length === 1) {
+      const name = names[0]!;
+      const claimant = /^\.(?:cleanup|upgrade)-(\d+)-[0-9a-f-]+$/.exec(name);
+      if (claimant) {
+        if (isProcessRunning(Number(claimant[1]))) return false;
+        unlinkSync(join(lockPath, name));
+        try { rmdirSync(lockPath); } catch { /* a replacement remains fenced */ }
+        return !existsSync(lockPath);
+      }
+      if (!name.startsWith("owner-")) return false;
+      const ownerPath = join(lockPath, name);
+      if (!staleOwner(readFileSync(ownerPath, "utf-8"))) return false;
+      // The UUID-bearing owner name is the identity claim. A replacement
+      // directory cannot contain this exact pathname.
+      unlinkSync(ownerPath);
+      try { rmdirSync(lockPath); } catch { /* a replacement non-empty directory stays fenced */ }
+      return !existsSync(lockPath);
+    }
+    const abandonedUpgrade = names.find((name) => {
+      const match = /^\.upgrade-(\d+)-[0-9a-f-]+$/.exec(name);
+      return match !== null && !isProcessRunning(Number(match[1]));
+    });
+    if (names.includes("owner") && abandonedUpgrade) {
+      unlinkSync(join(lockPath, abandonedUpgrade));
+    }
+    return false;
   } catch {
     return false;
   }
@@ -77,7 +110,7 @@ function removeStaleLegacyLock(lockPath: string, token: string): boolean {
 function removeStaleLock(lockPath: string, token: string): boolean {
   try {
     return statSync(lockPath).isDirectory()
-      ? removeStaleDirectoryLock(lockPath)
+      ? removeStaleDirectoryLock(lockPath, token)
       : removeStaleLegacyLock(lockPath, token);
   } catch {
     return false;

--- a/src/reducer-backed-store.ts
+++ b/src/reducer-backed-store.ts
@@ -6,8 +6,11 @@ import {
   linkSync,
   mkdirSync,
   openSync,
+  readdirSync,
   readFileSync,
   renameSync,
+  rmdirSync,
+  rmSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -29,45 +32,103 @@ interface LockOwner {
   contents: string;
 }
 
+function staleOwner(contents: string): boolean {
+  const pidPrefix = /^(\d+)/.exec(contents);
+  return pidPrefix ? !isProcessRunning(Number(pidPrefix[1])) : contents.length > 0;
+}
+
+function removeStaleDirectoryLock(lockPath: string, token: string): boolean {
+  const ownerPath = join(lockPath, "owner");
+  try {
+    const contents = readFileSync(ownerPath, "utf-8");
+    if (!staleOwner(contents)) return false;
+    const claimPath = join(lockPath, `.cleanup-${process.pid}-${token}`);
+    renameSync(ownerPath, claimPath);
+    unlinkSync(claimPath);
+    try { rmdirSync(lockPath); } catch { /* a replacement non-empty directory stays fenced */ }
+    return !existsSync(lockPath);
+  } catch {
+    try {
+      const names = readdirSync(lockPath);
+      if (names.length === 0) {
+        rmdirSync(lockPath);
+        return true;
+      }
+      const cleanup = names.find((name) => /^\.cleanup-(\d+)-/.test(name));
+      const pid = cleanup ? Number(/^\.cleanup-(\d+)-/.exec(cleanup)?.[1]) : undefined;
+      if (cleanup && pid !== undefined && !isProcessRunning(pid)) {
+        unlinkSync(join(lockPath, cleanup));
+        rmdirSync(lockPath);
+        return true;
+      }
+    } catch { /* incomplete or concurrently replaced directories stay fenced */ }
+    return false;
+  }
+}
+
+function removeStaleLegacyLock(lockPath: string, token: string): boolean {
+  const claimPath = `${lockPath}.${token}.legacy`;
+  try {
+    // The hard link binds inspection to one inode. New code publishes directories,
+    // so a replacement owner cannot be removed by this legacy-file migration path.
+    linkSync(lockPath, claimPath);
+    if (!staleOwner(readFileSync(claimPath, "utf-8"))) return false;
+    try { unlinkSync(lockPath); } catch { return false; }
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try { unlinkSync(claimPath); } catch { /* no migration claim was published */ }
+  }
+}
+
+function removeStaleLock(lockPath: string, token: string): boolean {
+  try {
+    return statSync(lockPath).isDirectory()
+      ? removeStaleDirectoryLock(lockPath, token)
+      : removeStaleLegacyLock(lockPath, token);
+  } catch {
+    return false;
+  }
+}
+
 function acquireLock(lockPath: string): LockOwner {
   mkdirSync(dirname(lockPath), { recursive: true });
   const token = randomUUID();
   const owner: LockOwner = { contents: `${process.pid}:${token}` };
   const candidatePath = `${lockPath}.${token}.candidate`;
-  writeFileSync(candidatePath, owner.contents, { flag: "wx" });
+  mkdirSync(candidatePath);
+  writeFileSync(join(candidatePath, "owner"), owner.contents, { flag: "wx" });
   try {
     for (let i = 0; i < LOCK_MAX_RETRIES; i++) {
       try {
-        // A hard link publishes the complete owner record atomically. Creating the
-        // final lock and filling it in separate syscalls leaves a stealable empty inode.
-        linkSync(candidatePath, lockPath);
+        // Renaming a complete non-empty directory publishes ownership atomically.
+        // Stale cleanup claims its fixed owner entry before removing the directory.
+        renameSync(candidatePath, lockPath);
         return owner;
-      } catch (e) {
-        if ((e as NodeJS.ErrnoException).code === "EEXIST") {
-          try {
-            const contents = readFileSync(lockPath, "utf-8");
-            const pidPrefix = /^(\d+)/.exec(contents);
-            if (contents.length > 0 && (!pidPrefix || !isProcessRunning(Number(pidPrefix[1])))) {
-              try { unlinkSync(lockPath); } catch { /* another acquirer won stale cleanup */ }
-              continue;
-            }
-          } catch { /* unreadable or concurrently replaced locks stay fenced */ }
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === "EEXIST" || code === "ENOTDIR" || code === "ENOTEMPTY" || code === "EPERM" || code === "EACCES") {
+          if (removeStaleLock(lockPath, token)) continue;
           const start = Date.now();
           while (Date.now() - start < LOCK_RETRY_MS) { /* busy wait */ }
           continue;
         }
-        throw e;
+        throw error;
       }
     }
     throw new Error(`Failed to acquire lock: ${lockPath}`);
   } finally {
-    try { unlinkSync(candidatePath); } catch { /* linked lock retains the inode */ }
+    try { rmSync(candidatePath, { recursive: true, force: true }); } catch { /* published candidate was renamed */ }
   }
 }
 
 function releaseLock(lockPath: string, owner: LockOwner): void {
   try {
-    if (readFileSync(lockPath, "utf-8") === owner.contents) unlinkSync(lockPath);
+    const ownerPath = join(lockPath, "owner");
+    if (readFileSync(ownerPath, "utf-8") !== owner.contents) return;
+    unlinkSync(ownerPath);
+    try { rmdirSync(lockPath); } catch { /* never remove a replacement owner's directory */ }
   } catch { /* never remove a lock whose ownership cannot be confirmed */ }
 }
 

--- a/src/runtime/notification-runtime.ts
+++ b/src/runtime/notification-runtime.ts
@@ -406,6 +406,11 @@ export function createNotificationRuntime(options: NotificationRuntimeOptions): 
       debug?.(`loop:fire #${notification.loopId} — session changed before delivery, dropping wake`);
       return false;
     }
+    const newer = notificationState.notificationsByKey[notification.key];
+    if (newer && newer.queueSequence > notification.queueSequence) {
+      debug?.(`loop:fire #${notification.loopId} — newer wake superseded in-flight delivery`);
+      return false;
+    }
     if (notification.expiresAt !== undefined && Date.now() >= notification.expiresAt) {
       debug?.(`loop:fire #${notification.loopId} — expiry boundary passed before delivery, dropping wake`);
       return false;

--- a/src/runtime/task-backlog-runtime.ts
+++ b/src/runtime/task-backlog-runtime.ts
@@ -81,6 +81,7 @@ export function createTaskBacklogRuntime(options: TaskBacklogRuntimeOptions): Ta
 
   function isAutoTaskWorkerLoop(entry: LoopEntry): boolean {
     return entry.status === "active"
+      && !entry.autoTask
       && !entry.workflow
       && !entry.orchestration
       && isAutoTaskWorkerPrompt(entry.prompt)
@@ -89,6 +90,7 @@ export function createTaskBacklogRuntime(options: TaskBacklogRuntimeOptions): Ta
 
   function isTaskBacklogLoop(entry: LoopEntry): boolean {
     return entry.status === "active"
+      && !entry.autoTask
       && !entry.workflow
       && !entry.orchestration
       && triggerHasEventSource(entry.trigger, "tasks:created")
@@ -102,7 +104,7 @@ export function createTaskBacklogRuntime(options: TaskBacklogRuntimeOptions): Ta
   function migrateAutoTaskWorkerPrompts(): number {
     let migrated = 0;
     for (const entry of getLoops()) {
-      if (entry.workflow || entry.orchestration) continue;
+      if (entry.autoTask || entry.workflow || entry.orchestration) continue;
       if (!isAutoTaskWorkerPrompt(entry.prompt)) continue;
       if (!triggerHasEventSource(entry.trigger, "tasks:created")) continue;
       if (entry.prompt === AUTO_TASK_WORKER_PROMPT && entry.taskBacklog) continue;
@@ -156,18 +158,19 @@ export function createTaskBacklogRuntime(options: TaskBacklogRuntimeOptions): Ta
       return current?.createdAt === entry.createdAt && isTaskBacklogLoop(current);
     });
     if (deletable.length === 0) return 0;
-    const deletedLoopIds = deletable.map((entry) => entry.id);
-    emitTaskBacklogEmpty?.(buildTaskBacklogEmptyPayload(deletedLoopIds));
-    let deleted = 0;
+    const deletedLoopIds: string[] = [];
     for (const entry of deletable) {
       if (isCurrent && !isCurrent()) break;
       const current = getLoops().find((candidate) => candidate.id === entry.id);
       if (current?.createdAt !== entry.createdAt || !isTaskBacklogLoop(current)) continue;
       deleteTaskBacklogLoop(entry, pending);
-      deleted++;
+      deletedLoopIds.push(entry.id);
     }
-    if (deleted > 0) updateWidget();
-    return deleted;
+    if (deletedLoopIds.length > 0) {
+      updateWidget();
+      emitTaskBacklogEmpty?.(buildTaskBacklogEmptyPayload(deletedLoopIds));
+    }
+    return deletedLoopIds.length;
   }
 
   type TaskBacklogDispatchResult = {

--- a/src/runtime/task-backlog-runtime.ts
+++ b/src/runtime/task-backlog-runtime.ts
@@ -118,7 +118,6 @@ export function createTaskBacklogRuntime(options: TaskBacklogRuntimeOptions): Ta
     removeTrigger(entry.id);
     recordDeletionTombstone?.(entry.id, { reason: "task_backlog_empty", pendingCount });
     deleteLoop(entry.id);
-    emitLoopAutodeleted?.(buildLoopAutodeletedPayload(entry, pendingCount));
   }
 
   async function adoptTaskBacklogLoops(
@@ -158,19 +157,22 @@ export function createTaskBacklogRuntime(options: TaskBacklogRuntimeOptions): Ta
       return current?.createdAt === entry.createdAt && isTaskBacklogLoop(current);
     });
     if (deletable.length === 0) return 0;
-    const deletedLoopIds: string[] = [];
+    const deletedEntries: LoopEntry[] = [];
     for (const entry of deletable) {
       if (isCurrent && !isCurrent()) break;
       const current = getLoops().find((candidate) => candidate.id === entry.id);
       if (current?.createdAt !== entry.createdAt || !isTaskBacklogLoop(current)) continue;
       deleteTaskBacklogLoop(entry, pending);
-      deletedLoopIds.push(entry.id);
+      deletedEntries.push(entry);
     }
-    if (deletedLoopIds.length > 0) {
+    if (deletedEntries.length > 0) {
       updateWidget();
-      emitTaskBacklogEmpty?.(buildTaskBacklogEmptyPayload(deletedLoopIds));
+      for (const entry of deletedEntries) {
+        emitLoopAutodeleted?.(buildLoopAutodeletedPayload(entry, pending));
+      }
+      emitTaskBacklogEmpty?.(buildTaskBacklogEmptyPayload(deletedEntries.map((entry) => entry.id)));
     }
-    return deletedLoopIds.length;
+    return deletedEntries.length;
   }
 
   type TaskBacklogDispatchResult = {

--- a/src/runtime/task-backlog-runtime.ts
+++ b/src/runtime/task-backlog-runtime.ts
@@ -48,6 +48,7 @@ export interface TaskBacklogRuntimeOptions {
   triggerHasEventSource: (trigger: Trigger | string, source: string) => boolean;
   emitLoopAutodeleted?: (payload: LoopAutodeletedPayload) => void;
   emitTaskBacklogEmpty?: (payload: TaskBacklogEmptyPayload) => void;
+  captureIsCurrent?: () => () => boolean;
   debug?: (...args: unknown[]) => void;
 }
 
@@ -74,17 +75,22 @@ export function createTaskBacklogRuntime(options: TaskBacklogRuntimeOptions): Ta
     triggerHasEventSource,
     emitLoopAutodeleted,
     emitTaskBacklogEmpty,
+    captureIsCurrent,
     debug,
   } = options;
 
   function isAutoTaskWorkerLoop(entry: LoopEntry): boolean {
     return entry.status === "active"
+      && !entry.workflow
+      && !entry.orchestration
       && isAutoTaskWorkerPrompt(entry.prompt)
       && triggerHasEventSource(entry.trigger, "tasks:created");
   }
 
   function isTaskBacklogLoop(entry: LoopEntry): boolean {
     return entry.status === "active"
+      && !entry.workflow
+      && !entry.orchestration
       && triggerHasEventSource(entry.trigger, "tasks:created")
       && (entry.taskBacklog === true || isAutoTaskWorkerLoop(entry));
   }
@@ -96,6 +102,7 @@ export function createTaskBacklogRuntime(options: TaskBacklogRuntimeOptions): Ta
   function migrateAutoTaskWorkerPrompts(): number {
     let migrated = 0;
     for (const entry of getLoops()) {
+      if (entry.workflow || entry.orchestration) continue;
       if (!isAutoTaskWorkerPrompt(entry.prompt)) continue;
       if (!triggerHasEventSource(entry.trigger, "tasks:created")) continue;
       if (entry.prompt === AUTO_TASK_WORKER_PROMPT && entry.taskBacklog) continue;
@@ -144,11 +151,23 @@ export function createTaskBacklogRuntime(options: TaskBacklogRuntimeOptions): Ta
     if (isCurrent && !isCurrent()) return 0;
     if (pending < 0 || pending > 0) return 0;
 
-    const deletedLoopIds = backlogLoops.map((entry) => entry.id);
+    const deletable = backlogLoops.filter((entry) => {
+      const current = getLoops().find((candidate) => candidate.id === entry.id);
+      return current?.createdAt === entry.createdAt && isTaskBacklogLoop(current);
+    });
+    if (deletable.length === 0) return 0;
+    const deletedLoopIds = deletable.map((entry) => entry.id);
     emitTaskBacklogEmpty?.(buildTaskBacklogEmptyPayload(deletedLoopIds));
-    for (const entry of backlogLoops) deleteTaskBacklogLoop(entry, pending);
-    updateWidget();
-    return backlogLoops.length;
+    let deleted = 0;
+    for (const entry of deletable) {
+      if (isCurrent && !isCurrent()) break;
+      const current = getLoops().find((candidate) => candidate.id === entry.id);
+      if (current?.createdAt !== entry.createdAt || !isTaskBacklogLoop(current)) continue;
+      deleteTaskBacklogLoop(entry, pending);
+      deleted++;
+    }
+    if (deleted > 0) updateWidget();
+    return deleted;
   }
 
   type TaskBacklogDispatchResult = {
@@ -161,18 +180,19 @@ export function createTaskBacklogRuntime(options: TaskBacklogRuntimeOptions): Ta
     return reduceTaskBacklogEvent(incoming as TaskBacklogEvent);
   };
 
-  const taskBacklogCoordinator = createCoordinator<TaskBacklogDispatchResult>({
-    reducers: [taskBacklogReducerHandler],
-    effectHandlers: {
-      CLEANUP_TASK_BACKLOG_LOOPS: async () => ({
-        kind: "cleanup",
-        cleaned: await cleanupTaskBacklogLoops(),
-      }),
-    },
-  });
-
   async function evaluateTaskBacklog(taskStore?: TaskStore, pendingCount?: number): Promise<{ entry?: LoopEntry; created: boolean; cleaned: number }> {
+    const isCurrent = captureIsCurrent?.();
     const resolvedPending = pendingCount ?? (taskStore ? taskStore.pendingCount() : await hasPendingTasks());
+    if (isCurrent && !isCurrent()) return { created: false, cleaned: 0 };
+    const taskBacklogCoordinator = createCoordinator<TaskBacklogDispatchResult>({
+      reducers: [taskBacklogReducerHandler],
+      effectHandlers: {
+        CLEANUP_TASK_BACKLOG_LOOPS: async () => ({
+          kind: "cleanup",
+          cleaned: await cleanupTaskBacklogLoops(isCurrent),
+        }),
+      },
+    });
     const results = await taskBacklogCoordinator.dispatch({
       type: "TASK_BACKLOG_EVALUATED",
       at: Date.now(),

--- a/src/store.ts
+++ b/src/store.ts
@@ -122,8 +122,20 @@ export interface ExpiredLoopRecord {
   reason: LoopExpiryReason;
 }
 
+export interface LoopFireExpectedIdentity {
+  createdAt: number;
+  updatedAt: number;
+  status: LoopEntry["status"];
+  fireCount: number;
+  workflowState?: string;
+  workflowTransitionSeq?: number;
+  workflowDefinitionRevision?: number;
+  workflowExecutionId?: string;
+  workflowMonitorId?: string;
+}
+
 export type LoopFireResult =
-  | { kind: "fired"; entry: LoopEntry }
+  | { kind: "fired"; entry: LoopEntry; settlement?: "deleted_by_fire_limit" }
   | { kind: "expired"; record: ExpiredLoopRecord }
   | { kind: "ignored" };
 
@@ -305,9 +317,24 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
     });
   }
 
-  private fireUnlocked(id: string, origin: LoopFireOrigin, now: number, settleExpiry: boolean): LoopFireResult {
+  private fireUnlocked(
+    id: string,
+    origin: LoopFireOrigin,
+    now: number,
+    settleExpiry: boolean,
+    expected?: LoopFireExpectedIdentity,
+  ): LoopFireResult {
     const entry = this.entries.get(id);
     if (entry?.status !== "active" || isTerminalWorkflowRun(entry?.workflow)) return { kind: "ignored" };
+    if (expected && (entry.createdAt !== expected.createdAt
+      || entry.updatedAt !== expected.updatedAt
+      || entry.status !== expected.status
+      || entry.fireCount !== expected.fireCount
+      || entry.workflow?.currentState !== expected.workflowState
+      || entry.workflow?.transitionSeq !== expected.workflowTransitionSeq
+      || entry.workflow?.definitionRevision !== expected.workflowDefinitionRevision
+      || entry.workflow?.activeExecution?.id !== expected.workflowExecutionId
+      || entry.workflow?.waitingMonitor?.monitorId !== expected.workflowMonitorId)) return { kind: "ignored" };
     if (now >= entry.expiresAt) {
       const record = settleExpiry ? this.expireEntryUnlocked(id, now) : undefined;
       return record ? { kind: "expired", record } : { kind: "ignored" };
@@ -330,7 +357,12 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
       ? structuredClone(fired)
       : undefined;
     if (limitReached) this.settleFireLimitUnlocked(fired, now);
-    return { kind: "fired", entry: this.entries.get(id) ?? deletedDelivery ?? fired };
+    const settled = this.entries.get(id);
+    return {
+      kind: "fired",
+      entry: settled ?? deletedDelivery ?? fired,
+      ...(!settled ? { settlement: "deleted_by_fire_limit" as const } : {}),
+    };
   }
 
   private settleFireLimitUnlocked(entry: LoopEntry, at: number): void {
@@ -365,8 +397,13 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
     return result.kind === "fired" ? result.entry : undefined;
   }
 
-  fireOrExpire(id: string, origin: LoopFireOrigin = "scheduler", now?: number): LoopFireResult {
-    return this.withLock(() => this.fireUnlocked(id, origin, now ?? Date.now(), true));
+  fireOrExpire(
+    id: string,
+    origin: LoopFireOrigin = "scheduler",
+    now?: number,
+    expected?: LoopFireExpectedIdentity,
+  ): LoopFireResult {
+    return this.withLock(() => this.fireUnlocked(id, origin, now ?? Date.now(), true, expected));
   }
 
   updateMetadata(id: string, fields: { trigger?: Trigger; prompt?: string; taskBacklog?: boolean }): { entry: LoopEntry | undefined; changedFields: string[] } {
@@ -410,6 +447,7 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
     fields: { prompt?: string; dynamic: Partial<DynamicLoopState> },
     expectedWorkflow?: {
       createdAt: number;
+      status: LoopEntry["status"];
       currentState: string;
       transitionSeq: number;
       definitionRevision: number;
@@ -420,6 +458,7 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
       const entry = this.entries.get(id);
       if (!entry) return undefined;
       if (expectedWorkflow && (entry.createdAt !== expectedWorkflow.createdAt
+        || entry.status !== expectedWorkflow.status
         || !entry.workflow
         || entry.workflow.currentState !== expectedWorkflow.currentState
         || entry.workflow.transitionSeq !== expectedWorkflow.transitionSeq

--- a/src/store.ts
+++ b/src/store.ts
@@ -329,7 +329,7 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
     if (expected && (entry.createdAt !== expected.createdAt
       || entry.updatedAt !== expected.updatedAt
       || entry.status !== expected.status
-      || entry.fireCount !== expected.fireCount
+      || (entry.fireCount ?? 0) !== expected.fireCount
       || entry.workflow?.currentState !== expected.workflowState
       || entry.workflow?.transitionSeq !== expected.workflowTransitionSeq
       || entry.workflow?.definitionRevision !== expected.workflowDefinitionRevision

--- a/src/store.ts
+++ b/src/store.ts
@@ -84,11 +84,30 @@ function normalizePauseRecord(entry: LoopEntry): LoopPauseRecord | undefined {
   return pause;
 }
 
+function validateControllerDomain(entry: {
+  workflow?: unknown;
+  orchestration?: unknown;
+  autoTask?: boolean;
+  taskBacklog?: boolean;
+  trigger: Trigger;
+}): void {
+  if (entry.autoTask && entry.taskBacklog) {
+    throw new Error("Malformed loop controller: auto-task and task-backlog behavior are mutually exclusive");
+  }
+  if (entry.workflow && (entry.autoTask || entry.taskBacklog || entry.orchestration)) {
+    throw new Error("Malformed loop controller: workflow cannot own standalone tasks or orchestration behavior");
+  }
+  if (entry.orchestration && (entry.autoTask || entry.taskBacklog)) {
+    throw new Error("Malformed loop controller: orchestration cannot own standalone task behavior");
+  }
+  if ((entry.workflow || entry.orchestration) && entry.trigger.type !== "dynamic") {
+    throw new Error("Malformed loop controller: workflow and orchestration controllers require a dynamic trigger");
+  }
+}
+
 function normalizeLoopEntry(entry: LoopEntry): LoopEntry {
   const pause = normalizePauseRecord(entry);
-  if (entry.workflow && (entry.autoTask || entry.taskBacklog || entry.orchestration)) {
-    throw new Error("Malformed loop controller: workflow cannot own standalone task or orchestration behavior");
-  }
+  validateControllerDomain(entry);
   return {
     ...entry,
     ...(pause ? { pause } : {}),
@@ -177,15 +196,12 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
       if (this.entries.size >= MAX_LOOPS) {
         throw new Error(`Maximum of ${MAX_LOOPS} loops reached. Delete some before creating new ones.`);
       }
+      validateControllerDomain({ trigger, ...opts });
       if (opts.workflow) {
-        if (trigger.type !== "dynamic") throw new Error("Workflow loops require a dynamic trigger.");
-        if (opts.autoTask || opts.taskBacklog) throw new Error("Workflow controllers cannot create or adopt standalone tasks.");
         const validationError = validateWorkflowDefinition(opts.workflow);
         if (validationError) throw new Error(`Invalid workflow: ${validationError}`);
       }
       if (opts.orchestration) {
-        if (trigger.type !== "dynamic") throw new Error("Orchestration loops require a dynamic trigger.");
-        if (opts.workflow) throw new Error("A loop cannot own both workflow and orchestration state.");
         const validationError = validateOrchestrationDefinition(opts.orchestration.definition);
         if (validationError) throw new Error(`Invalid orchestration: ${validationError}`);
       }
@@ -358,6 +374,13 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
       const current = this.entries.get(id);
       if (!current) return { entry: undefined, changedFields: [] };
 
+      const candidate = {
+        ...current,
+        ...(fields.trigger !== undefined ? { trigger: fields.trigger } : {}),
+        ...(fields.taskBacklog !== undefined ? { taskBacklog: fields.taskBacklog } : {}),
+      };
+      validateControllerDomain(candidate);
+
       const changedFields: string[] = [];
       const now = Date.now();
 
@@ -382,9 +405,26 @@ export class LoopStore extends ReducerBackedStore<LoopEntry, LoopReducerState, L
   }
 
 
-  updateDynamic(id: string, fields: { prompt?: string; dynamic: Partial<DynamicLoopState> }): LoopEntry | undefined {
+  updateDynamic(
+    id: string,
+    fields: { prompt?: string; dynamic: Partial<DynamicLoopState> },
+    expectedWorkflow?: {
+      createdAt: number;
+      currentState: string;
+      transitionSeq: number;
+      definitionRevision: number;
+      activeExecutionId?: string;
+    },
+  ): LoopEntry | undefined {
     return this.withLock(() => {
-      if (!this.entries.has(id)) return undefined;
+      const entry = this.entries.get(id);
+      if (!entry) return undefined;
+      if (expectedWorkflow && (entry.createdAt !== expectedWorkflow.createdAt
+        || !entry.workflow
+        || entry.workflow.currentState !== expectedWorkflow.currentState
+        || entry.workflow.transitionSeq !== expectedWorkflow.transitionSeq
+        || entry.workflow.definitionRevision !== expectedWorkflow.definitionRevision
+        || entry.workflow.activeExecution?.id !== expectedWorkflow.activeExecutionId)) return undefined;
       this.applyReducerEvent({
         type: "LOOP_DYNAMIC_UPDATED",
         at: Date.now(),

--- a/src/task-store.ts
+++ b/src/task-store.ts
@@ -252,7 +252,7 @@ export class TaskStore extends ReducerBackedStore<TaskEntry, TaskReducerState, T
 
   pendingCount(): number {
     let count = 0;
-    for (const t of this.entries.values()) {
+    for (const t of this.list()) {
       if (t.status === "pending" || t.status === "in_progress") count++;
     }
     return count;

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -138,7 +138,7 @@ function workflowDefaultMaxFires(definition: WorkflowDefinition): number {
       hasCadence = true;
       if (state.loop.maxFires === undefined) hasUnboundedCadence = true;
       else automaticFires += state.loop.maxFires;
-      if (state.loop.startImmediately) automaticFires += 1;
+      if (state.loop.startImmediately) automaticFires += state.maxAttempts ?? 1;
     } else {
       automaticFires += state.maxAttempts ?? 1;
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -165,6 +165,60 @@ describe("workflow runtime wiring", () => {
     vi.useRealTimers();
   });
 
+  it("post-fire bookkeeping cannot mutate an advanced cadence destination", async () => {
+    const { pi, toolMap, extensionHandlers, sentMessages } = createMockPi();
+    extension(pi as any);
+    const sessionId = "workflow-bookkeeping-race-session";
+    const ctx = createCtx({ sessionId });
+    for (const handler of extensionHandlers.get("turn_start") ?? []) await handler(null, ctx);
+    const loopPath = resolveLoopStorePath({ loopScope: "session" }, sessionId)!;
+    const original = LoopStore.prototype.fireOrExpire;
+    let interposed = false;
+    vi.spyOn(LoopStore.prototype, "fireOrExpire").mockImplementation(function (...args) {
+      const result = original.apply(this, args);
+      if (!interposed && result.kind === "fired" && result.entry.workflow?.currentState === "prepare") {
+        interposed = true;
+        const workflow = new LoopStore(loopPath).get(result.entry.id)!.workflow!;
+        expect(new LoopStore(loopPath).transitionWorkflow(result.entry.id, {
+          outcome: "ready",
+          evidence: "Preparation completed concurrently.",
+        }, {
+          currentState: workflow.currentState,
+          transitionSeq: workflow.transitionSeq,
+          definitionRevision: workflow.definitionRevision,
+          activeExecutionId: workflow.activeExecution?.id,
+        }).applied).toBe(true);
+      }
+      return result;
+    });
+
+    await toolMap.get("WorkflowCreate")!.execute!("workflow-bookkeeping-race", {
+      goal: "Prepare then poll",
+      definition: JSON.stringify({
+        version: 1,
+        initialState: "prepare",
+        states: {
+          prepare: { prompt: "Prepare.", on: { ready: "poll" } },
+          poll: {
+            prompt: "Poll later.",
+            loop: { schedule: "* * * * *", maxFires: 1, startImmediately: false },
+            on: { done: "done" },
+          },
+          done: { prompt: "Done.", terminal: "completed" },
+        },
+      }),
+    });
+    await flushAsync();
+
+    expect(interposed).toBe(true);
+    expect(new LoopStore(loopPath).get("1")).toMatchObject({
+      status: "active",
+      dynamic: { state: "poll", awaitingUpdate: false },
+      workflow: { currentState: "poll", transitionSeq: 1 },
+    });
+    expect(sentMessages.some((item) => item.message.content.includes("Poll later."))).toBe(false);
+  });
+
   it("persists reissued work and delivers only the fresh workflow instruction", async () => {
     const { pi, toolMap, extensionHandlers, sentMessages } = createMockPi();
     extension(pi as any);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -241,6 +241,61 @@ describe("workflow runtime wiring", () => {
     expect(sentMessages.some((item) => item.message.content.includes("Do not deliver paused work."))).toBe(false);
   });
 
+  it.each(["pause", "transition"] as const)("does not launder a late workflow %s through final delivery", async (action) => {
+    const { pi, toolMap, extensionHandlers, sentMessages } = createMockPi();
+    const sessionId = `workflow-final-read-${action}`;
+    clearTestLoopStore(sessionId);
+    extension(pi as any);
+    const ctx = createCtx({ sessionId });
+    for (const handler of extensionHandlers.get("turn_start") ?? []) await handler(null, ctx);
+    const loopPath = resolveLoopStorePath({ loopScope: "session" }, sessionId)!;
+    const originalUpdate = LoopStore.prototype.updateDynamic;
+    const originalGet = LoopStore.prototype.get;
+    let target: LoopStore | undefined;
+    let reads = 0;
+    let interposed = false;
+    vi.spyOn(LoopStore.prototype, "updateDynamic").mockImplementation(function (...args) {
+      const result = originalUpdate.apply(this, args);
+      if (result?.workflow?.currentState === "prepare") target = this;
+      return result;
+    });
+    vi.spyOn(LoopStore.prototype, "get").mockImplementation(function (id) {
+      if (this === target && ++reads === 2) {
+        interposed = true;
+        const peer = new LoopStore(loopPath);
+        if (action === "pause") peer.pause(id, "administrative", "Operator pause");
+        else {
+          const workflow = originalGet.call(peer, id)!.workflow!;
+          expect(peer.transitionWorkflow(id, { outcome: "ready", evidence: "Preparation completed." }, {
+            currentState: workflow.currentState,
+            transitionSeq: workflow.transitionSeq,
+            definitionRevision: workflow.definitionRevision,
+            activeExecutionId: workflow.activeExecution?.id,
+          }).applied).toBe(true);
+        }
+      }
+      return originalGet.call(this, id);
+    });
+
+    await toolMap.get("WorkflowCreate")!.execute!("workflow-final-read", {
+      goal: "Prepare then poll",
+      maxFires: 10,
+      definition: JSON.stringify({
+        version: 1,
+        initialState: "prepare",
+        states: {
+          prepare: { prompt: "Prepare only while active.", on: { ready: "poll" } },
+          poll: { prompt: "Poll only on cadence.", loop: { schedule: "* * * * *", maxFires: 2 }, on: { done: "done" } },
+          done: { prompt: "Done.", terminal: "completed" },
+        },
+      }),
+    });
+    await Promise.resolve();
+
+    expect(interposed).toBe(true);
+    expect(sentMessages).toHaveLength(0);
+  });
+
   it("post-fire bookkeeping cannot mutate an advanced cadence destination", async () => {
     const { pi, toolMap, extensionHandlers, sentMessages } = createMockPi();
     const sessionId = "workflow-bookkeeping-race-session";

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -165,6 +165,80 @@ describe("workflow runtime wiring", () => {
     vi.useRealTimers();
   });
 
+  it("stale activation cannot fire a workflow destination that disabled immediate start", async () => {
+    const { pi, toolMap, extensionHandlers, sentMessages } = createMockPi();
+    extension(pi as any);
+    const sessionId = "workflow-prefire-race-session";
+    const ctx = createCtx({ sessionId });
+    for (const handler of extensionHandlers.get("turn_start") ?? []) await handler(null, ctx);
+    const loopPath = resolveLoopStorePath({ loopScope: "session" }, sessionId)!;
+    const original = LoopStore.prototype.fireOrExpire;
+    let interposed = false;
+    vi.spyOn(LoopStore.prototype, "fireOrExpire").mockImplementation(function (...args) {
+      if (!interposed) {
+        interposed = true;
+        const workflow = new LoopStore(loopPath).get(String(args[0]))!.workflow!;
+        expect(new LoopStore(loopPath).transitionWorkflow(String(args[0]), {
+          outcome: "ready", evidence: "Preparation completed concurrently.",
+        }, {
+          currentState: workflow.currentState,
+          transitionSeq: workflow.transitionSeq,
+          definitionRevision: workflow.definitionRevision,
+          activeExecutionId: workflow.activeExecution?.id,
+        }).applied).toBe(true);
+      }
+      return original.apply(this, args);
+    });
+
+    await toolMap.get("WorkflowCreate")!.execute!("workflow-prefire-race", {
+      goal: "Prepare then poll",
+      definition: JSON.stringify({
+        version: 1,
+        initialState: "prepare",
+        states: {
+          prepare: { prompt: "Prepare.", on: { ready: "poll" } },
+          poll: { prompt: "Poll later.", loop: { schedule: "* * * * *", maxFires: 1 }, on: { done: "done" } },
+          done: { prompt: "Done.", terminal: "completed" },
+        },
+      }),
+    });
+    await flushAsync();
+
+    expect(new LoopStore(loopPath).get("1")).toMatchObject({ fireCount: 0, workflow: { currentState: "poll" } });
+    expect(sentMessages.some((item) => item.message.content.includes("Poll later."))).toBe(false);
+  });
+
+  it("post-fire administrative pause suppresses workflow delivery", async () => {
+    const { pi, toolMap, extensionHandlers, sentMessages } = createMockPi();
+    extension(pi as any);
+    const sessionId = "workflow-postfire-pause-session";
+    const ctx = createCtx({ sessionId });
+    for (const handler of extensionHandlers.get("turn_start") ?? []) await handler(null, ctx);
+    const loopPath = resolveLoopStorePath({ loopScope: "session" }, sessionId)!;
+    const original = LoopStore.prototype.fireOrExpire;
+    vi.spyOn(LoopStore.prototype, "fireOrExpire").mockImplementation(function (...args) {
+      const result = original.apply(this, args);
+      if (result.kind === "fired") new LoopStore(loopPath).pause(result.entry.id, "administrative", "Operator pause");
+      return result;
+    });
+
+    await toolMap.get("WorkflowCreate")!.execute!("workflow-postfire-pause", {
+      goal: "Pause before delivery",
+      definition: JSON.stringify({
+        version: 1,
+        initialState: "work",
+        states: {
+          work: { prompt: "Do not deliver paused work.", on: { done: "done" } },
+          done: { prompt: "Done.", terminal: "completed" },
+        },
+      }),
+    });
+    await flushAsync();
+
+    expect(new LoopStore(loopPath).get("1")?.status).toBe("paused");
+    expect(sentMessages.some((item) => item.message.content.includes("Do not deliver paused work."))).toBe(false);
+  });
+
   it("post-fire bookkeeping cannot mutate an advanced cadence destination", async () => {
     const { pi, toolMap, extensionHandlers, sentMessages } = createMockPi();
     extension(pi as any);
@@ -1637,6 +1711,22 @@ describe("native task fallback", () => {
 
     const result = await loopList!.execute?.("2", {});
     expect(result.content[0].text).toBe("No loops configured. Use LoopCreate to set up a schedule.");
+  });
+
+  it("delivers the final bounded idle wake after atomic controller retirement", async () => {
+    const { pi, toolMap, sentMessages } = createMockPi();
+    extension(pi as any);
+
+    await toolMap.get("LoopCreate")!.execute!("idle-final", {
+      trigger: "idle",
+      prompt: "Deliver the final idle iteration.",
+      triggerType: "idle",
+      maxFires: 1,
+    });
+    await flushAsync();
+
+    expect((await toolMap.get("LoopList")!.execute!("list", {})).content[0].text).toContain("No loops configured");
+    expect(sentMessages.filter((sent) => sent.message.content.includes("Deliver the final idle iteration."))).toHaveLength(1);
   });
 
   it("does not consume a final fire when a stale runtime cannot dispatch its wake", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -167,8 +167,9 @@ describe("workflow runtime wiring", () => {
 
   it("stale activation cannot fire a workflow destination that disabled immediate start", async () => {
     const { pi, toolMap, extensionHandlers, sentMessages } = createMockPi();
-    extension(pi as any);
     const sessionId = "workflow-prefire-race-session";
+    clearTestLoopStore(sessionId);
+    extension(pi as any);
     const ctx = createCtx({ sessionId });
     for (const handler of extensionHandlers.get("turn_start") ?? []) await handler(null, ctx);
     const loopPath = resolveLoopStorePath({ loopScope: "session" }, sessionId)!;
@@ -210,8 +211,9 @@ describe("workflow runtime wiring", () => {
 
   it("post-fire administrative pause suppresses workflow delivery", async () => {
     const { pi, toolMap, extensionHandlers, sentMessages } = createMockPi();
-    extension(pi as any);
     const sessionId = "workflow-postfire-pause-session";
+    clearTestLoopStore(sessionId);
+    extension(pi as any);
     const ctx = createCtx({ sessionId });
     for (const handler of extensionHandlers.get("turn_start") ?? []) await handler(null, ctx);
     const loopPath = resolveLoopStorePath({ loopScope: "session" }, sessionId)!;
@@ -241,8 +243,9 @@ describe("workflow runtime wiring", () => {
 
   it("post-fire bookkeeping cannot mutate an advanced cadence destination", async () => {
     const { pi, toolMap, extensionHandlers, sentMessages } = createMockPi();
-    extension(pi as any);
     const sessionId = "workflow-bookkeeping-race-session";
+    clearTestLoopStore(sessionId);
+    extension(pi as any);
     const ctx = createCtx({ sessionId });
     for (const handler of extensionHandlers.get("turn_start") ?? []) await handler(null, ctx);
     const loopPath = resolveLoopStorePath({ loopScope: "session" }, sessionId)!;
@@ -1714,6 +1717,7 @@ describe("native task fallback", () => {
   });
 
   it("delivers the final bounded idle wake after atomic controller retirement", async () => {
+    vi.stubEnv("PI_LOOP_SCOPE", "memory");
     const { pi, toolMap, sentMessages } = createMockPi();
     extension(pi as any);
 
@@ -1723,10 +1727,11 @@ describe("native task fallback", () => {
       triggerType: "idle",
       maxFires: 1,
     });
-    await flushAsync();
+    await Promise.resolve();
 
     expect((await toolMap.get("LoopList")!.execute!("list", {})).content[0].text).toContain("No loops configured");
     expect(sentMessages.filter((sent) => sent.message.content.includes("Deliver the final idle iteration."))).toHaveLength(1);
+    vi.unstubAllEnvs();
   });
 
   it("does not consume a final fire when a stale runtime cannot dispatch its wake", async () => {

--- a/test/injection.test.ts
+++ b/test/injection.test.ts
@@ -522,8 +522,8 @@ describe("loop:fire custom message delivery", () => {
   it("supersession: assigns same-key wake order before asynchronous task admission completes", async () => {
     const { pi, sentMessages, emitExtension, eventHandlers } = createMockPi();
     const pendingRequests: Array<{ requestId: string }> = [];
-    let thirdLookupStarted!: () => void;
-    const thirdLookup = new Promise<void>((resolve) => { thirdLookupStarted = resolve; });
+    let lookupStarted!: () => void;
+    const lookup = new Promise<void>((resolve) => { lookupStarted = resolve; });
     pi.events.on(TASKS_RPC.ping, ({ requestId }: { requestId: string }) => {
       pi.events.emit(replyChannel(TASKS_RPC.ping, requestId), {
         success: true,
@@ -532,7 +532,7 @@ describe("loop:fire custom message delivery", () => {
     });
     pi.events.on(TASKS_RPC.pending, (request: { requestId: string }) => {
       pendingRequests.push(request);
-      if (pendingRequests.length === 3) thirdLookupStarted();
+      lookupStarted();
     });
     const extension = await import("../src/index.js");
     extension.default(pi);
@@ -548,20 +548,13 @@ describe("loop:fire custom message delivery", () => {
       loopId: "13", prompt: "Latest prompt", trigger: { type: "cron", schedule: "*/1 * * * *" },
       timestamp: 2, autoTask: true, recurring: true,
     });
-    expect(pendingRequests).toHaveLength(2);
-
-    pi.events.emit(replyChannel(TASKS_RPC.pending, pendingRequests[1]!.requestId), {
-      success: true, data: { pending: 1 },
-    });
-    await newWake;
-    pi.events.emit(replyChannel(TASKS_RPC.pending, pendingRequests[0]!.requestId), {
-      success: true, data: { pending: 1 },
-    });
-    await oldWake;
+    await Promise.all([oldWake, newWake]);
+    expect(pendingRequests).toHaveLength(0);
 
     const ended = emitExtension("agent_end", null, ctx);
-    await thirdLookup;
-    pi.events.emit(replyChannel(TASKS_RPC.pending, pendingRequests[2]!.requestId), {
+    await lookup;
+    expect(pendingRequests).toHaveLength(1);
+    pi.events.emit(replyChannel(TASKS_RPC.pending, pendingRequests[0]!.requestId), {
       success: true, data: { pending: 1 },
     });
     await ended;

--- a/test/injection.test.ts
+++ b/test/injection.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { replyChannel, TASKS_RPC } from "../src/rpc/channels.js";
 import { createCtx, createMockPi, flushAsync } from "./helpers/mock-pi.js";
 
 describe("loop:fire custom message delivery", () => {
@@ -516,6 +517,58 @@ describe("loop:fire custom message delivery", () => {
 
     expect(sentMessages).toHaveLength(1);
     expect(sentMessages[0].message.content).toContain("Deliver after current work finishes");
+  });
+
+  it("supersession: assigns same-key wake order before asynchronous task admission completes", async () => {
+    const { pi, sentMessages, emitExtension, eventHandlers } = createMockPi();
+    const pendingRequests: Array<{ requestId: string }> = [];
+    let thirdLookupStarted!: () => void;
+    const thirdLookup = new Promise<void>((resolve) => { thirdLookupStarted = resolve; });
+    pi.events.on(TASKS_RPC.ping, ({ requestId }: { requestId: string }) => {
+      pi.events.emit(replyChannel(TASKS_RPC.ping, requestId), {
+        success: true,
+        data: { version: 2, provider: "external-test-provider" },
+      });
+    });
+    pi.events.on(TASKS_RPC.pending, (request: { requestId: string }) => {
+      pendingRequests.push(request);
+      if (pendingRequests.length === 3) thirdLookupStarted();
+    });
+    const extension = await import("../src/index.js");
+    extension.default(pi);
+
+    const ctx = createCtx(false);
+    await emitExtension("agent_start", null, ctx);
+    const fire = eventHandlers.get("loop:fire")![0]! as (event: unknown) => Promise<void>;
+    const oldWake = fire({
+      loopId: "13", prompt: "Old prompt", trigger: { type: "cron", schedule: "*/1 * * * *" },
+      timestamp: 1, autoTask: true, recurring: true,
+    });
+    const newWake = fire({
+      loopId: "13", prompt: "Latest prompt", trigger: { type: "cron", schedule: "*/1 * * * *" },
+      timestamp: 2, autoTask: true, recurring: true,
+    });
+    expect(pendingRequests).toHaveLength(2);
+
+    pi.events.emit(replyChannel(TASKS_RPC.pending, pendingRequests[1]!.requestId), {
+      success: true, data: { pending: 1 },
+    });
+    await newWake;
+    pi.events.emit(replyChannel(TASKS_RPC.pending, pendingRequests[0]!.requestId), {
+      success: true, data: { pending: 1 },
+    });
+    await oldWake;
+
+    const ended = emitExtension("agent_end", null, ctx);
+    await thirdLookup;
+    pi.events.emit(replyChannel(TASKS_RPC.pending, pendingRequests[2]!.requestId), {
+      success: true, data: { pending: 1 },
+    });
+    await ended;
+
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0]?.message.content).toContain("Latest prompt");
+    expect(sentMessages[0]?.message.content).not.toContain("Old prompt");
   });
 
   it("dedupes buffered recurring fires by loop id and keeps the latest prompt", async () => {

--- a/test/lock-publication.test.ts
+++ b/test/lock-publication.test.ts
@@ -1,0 +1,148 @@
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const hooks = vi.hoisted(() => ({
+  replaceLegacy: false,
+  beforePublish: undefined as ((lockPath: string) => void) | undefined,
+  afterPublish: undefined as ((lockPath: string, ownerPath: string) => void) | undefined,
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const fs = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...fs,
+    renameSync(source: import("node:fs").PathLike, target: import("node:fs").PathLike) {
+      if (String(source).endsWith(".candidate")) {
+        hooks.beforePublish?.(String(target));
+        // Model replacing rename semantics; native behavior is separately checked by Windows CI.
+        if (hooks.replaceLegacy && fs.existsSync(target) && fs.statSync(target).isFile()) fs.unlinkSync(target);
+      }
+      return fs.renameSync(source, target);
+    },
+    linkSync(source: import("node:fs").PathLike, target: import("node:fs").PathLike) {
+      const publication = dirname(String(source)).endsWith(".candidate");
+      if (publication) hooks.beforePublish?.(dirname(String(target)));
+      fs.linkSync(source, target);
+      if (publication) hooks.afterPublish?.(dirname(String(target)), String(target));
+    },
+  };
+});
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { LoopStore } from "../src/store.js";
+
+const dirs: string[] = [];
+afterEach(() => {
+  hooks.replaceLegacy = false;
+  hooks.beforePublish = undefined;
+  hooks.afterPublish = undefined;
+  vi.restoreAllMocks();
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function fixture() {
+  const dir = mkdtempSync(join(tmpdir(), "pi-loop-publication-"));
+  dirs.push(dir);
+  const path = join(dir, "loops.json");
+  const store = new LoopStore(path);
+  store.create({ type: "dynamic" }, "original", { recurring: true });
+  const before = readFileSync(path, "utf8");
+  let tick = 0;
+  vi.spyOn(Date, "now").mockImplementation(() => (tick += 100));
+  return { dir, path, lockPath: `${path}.lock`, store, before };
+}
+
+function expectUnchanged(f: ReturnType<typeof fixture>) {
+  expect(readFileSync(f.path, "utf8")).toBe(f.before);
+  expect(f.store.list()).toHaveLength(1);
+  expect(readdirSync(f.dir).filter((name) => name.endsWith(".candidate"))).toEqual([]);
+}
+
+describe("non-replacing initialized lock claims", () => {
+  it.each(["", `${process.pid}:`, `${process.pid}:live-owner`])("preserves a closed legacy file with contents %j even with replacing rename", (contents) => {
+    const f = fixture();
+    writeFileSync(f.lockPath, contents);
+    const inode = statSync(f.lockPath).ino;
+    hooks.replaceLegacy = true;
+    expect(() => f.store.create({ type: "dynamic" }, "must not enter")).toThrow(/lock/i);
+    expect(readFileSync(f.lockPath, "utf8")).toBe(contents);
+    expect(statSync(f.lockPath).ino).toBe(inode);
+    expectUnchanged(f);
+  });
+
+  it("preserves a live legacy file appearing immediately before publication", () => {
+    const f = fixture();
+    hooks.replaceLegacy = true;
+    hooks.beforePublish = (lockPath) => {
+      hooks.beforePublish = undefined;
+      if (existsSync(lockPath)) rmdirSync(lockPath);
+      writeFileSync(lockPath, `${process.pid}:late-legacy`);
+    };
+    expect(() => f.store.create({ type: "dynamic" }, "must not enter")).toThrow(/lock/i);
+    expect(hooks.beforePublish).toBeUndefined();
+    expect(readFileSync(f.lockPath, "utf8")).toBe(`${process.pid}:late-legacy`);
+    expectUnchanged(f);
+  });
+
+  it("does not enter a live directory replacing empty scaffolding before publication", () => {
+    const f = fixture();
+    hooks.beforePublish = (lockPath) => {
+      hooks.beforePublish = undefined;
+      if (existsSync(lockPath)) rmdirSync(lockPath);
+      mkdirSync(lockPath);
+      writeFileSync(join(lockPath, `owner-${process.pid}-replacement`), `${process.pid}:replacement`);
+    };
+    expect(() => f.store.create({ type: "dynamic" }, "must not enter")).toThrow(/lock/i);
+    expect(readdirSync(f.lockPath)).toEqual([`owner-${process.pid}-replacement`]);
+    expectUnchanged(f);
+  });
+
+  it("a contender cannot enter while an initialized claim is awaiting admission", () => {
+    const f = fixture();
+    let publications = 0;
+    hooks.afterPublish = (_lockPath, ownerPath) => {
+      hooks.afterPublish = undefined;
+      publications++;
+      expect(readFileSync(ownerPath, "utf8")).toMatch(new RegExp(`^${process.pid}:[0-9a-f-]+$`));
+      const contender = new LoopStore(f.path);
+      expect(() => contender.create({ type: "dynamic" }, "contender")).toThrow(/lock/i);
+      expect(readFileSync(f.path, "utf8")).toBe(f.before);
+      expect(existsSync(ownerPath)).toBe(true);
+    };
+    f.store.create({ type: "dynamic" }, "owner");
+    expect(publications).toBe(1);
+    expect(f.store.list().map((entry) => entry.prompt)).toEqual(["original", "owner"]);
+    expect(existsSync(f.lockPath)).toBe(false);
+  });
+
+  it("withdraws only its own claim on inspection failure", () => {
+    const f = fixture();
+    hooks.afterPublish = () => {
+      hooks.afterPublish = undefined;
+      throw Object.assign(new Error("publication inspection failed"), { code: "EIO" });
+    };
+    expect(() => f.store.create({ type: "dynamic" }, "must not enter")).toThrow(/inspection/);
+    expectUnchanged(f);
+    expect(!existsSync(f.lockPath) || readdirSync(f.lockPath).length === 0).toBe(true);
+    f.store.create({ type: "dynamic" }, "recovered");
+    expect(f.store.list()).toHaveLength(2);
+  });
+
+  it.each([false, true])("reclaims individually dead claims without stealing live claims (live=%s)", (live) => {
+    const f = fixture();
+    mkdirSync(f.lockPath);
+    writeFileSync(join(f.lockPath, "owner-999999-dead-a"), "999999:dead-a");
+    writeFileSync(join(f.lockPath, "owner-999998-dead-b"), "999998:dead-b");
+    if (live) writeFileSync(join(f.lockPath, `owner-${process.pid}-live`), `${process.pid}:live`);
+    if (live) {
+      expect(() => f.store.create({ type: "dynamic" }, "must not enter")).toThrow(/lock/i);
+      expect(readdirSync(f.lockPath)).toEqual([`owner-${process.pid}-live`]);
+      expectUnchanged(f);
+    } else {
+      f.store.create({ type: "dynamic" }, "recovered");
+      expect(f.store.list()).toHaveLength(2);
+      expect(existsSync(f.lockPath)).toBe(false);
+    }
+  });
+});

--- a/test/lock-publication.test.ts
+++ b/test/lock-publication.test.ts
@@ -65,7 +65,7 @@ describe("non-replacing initialized lock claims", () => {
     writeFileSync(f.lockPath, contents);
     const inode = statSync(f.lockPath).ino;
     hooks.replaceLegacy = true;
-    expect(() => f.store.create({ type: "dynamic" }, "must not enter")).toThrow(/lock/i);
+    expect(() => f.store.create({ type: "dynamic" }, "must not enter", {})).toThrow(/lock/i);
     expect(readFileSync(f.lockPath, "utf8")).toBe(contents);
     expect(statSync(f.lockPath).ino).toBe(inode);
     expectUnchanged(f);
@@ -79,7 +79,7 @@ describe("non-replacing initialized lock claims", () => {
       if (existsSync(lockPath)) rmdirSync(lockPath);
       writeFileSync(lockPath, `${process.pid}:late-legacy`);
     };
-    expect(() => f.store.create({ type: "dynamic" }, "must not enter")).toThrow(/lock/i);
+    expect(() => f.store.create({ type: "dynamic" }, "must not enter", {})).toThrow(/lock/i);
     expect(hooks.beforePublish).toBeUndefined();
     expect(readFileSync(f.lockPath, "utf8")).toBe(`${process.pid}:late-legacy`);
     expectUnchanged(f);
@@ -93,7 +93,7 @@ describe("non-replacing initialized lock claims", () => {
       mkdirSync(lockPath);
       writeFileSync(join(lockPath, `owner-${process.pid}-replacement`), `${process.pid}:replacement`);
     };
-    expect(() => f.store.create({ type: "dynamic" }, "must not enter")).toThrow(/lock/i);
+    expect(() => f.store.create({ type: "dynamic" }, "must not enter", {})).toThrow(/lock/i);
     expect(readdirSync(f.lockPath)).toEqual([`owner-${process.pid}-replacement`]);
     expectUnchanged(f);
   });
@@ -106,11 +106,11 @@ describe("non-replacing initialized lock claims", () => {
       publications++;
       expect(readFileSync(ownerPath, "utf8")).toMatch(new RegExp(`^${process.pid}:[0-9a-f-]+$`));
       const contender = new LoopStore(f.path);
-      expect(() => contender.create({ type: "dynamic" }, "contender")).toThrow(/lock/i);
+      expect(() => contender.create({ type: "dynamic" }, "contender", {})).toThrow(/lock/i);
       expect(readFileSync(f.path, "utf8")).toBe(f.before);
       expect(existsSync(ownerPath)).toBe(true);
     };
-    f.store.create({ type: "dynamic" }, "owner");
+    f.store.create({ type: "dynamic" }, "owner", {});
     expect(publications).toBe(1);
     expect(f.store.list().map((entry) => entry.prompt)).toEqual(["original", "owner"]);
     expect(existsSync(f.lockPath)).toBe(false);
@@ -122,10 +122,10 @@ describe("non-replacing initialized lock claims", () => {
       hooks.afterPublish = undefined;
       throw Object.assign(new Error("publication inspection failed"), { code: "EIO" });
     };
-    expect(() => f.store.create({ type: "dynamic" }, "must not enter")).toThrow(/inspection/);
+    expect(() => f.store.create({ type: "dynamic" }, "must not enter", {})).toThrow(/inspection/);
     expectUnchanged(f);
     expect(!existsSync(f.lockPath) || readdirSync(f.lockPath).length === 0).toBe(true);
-    f.store.create({ type: "dynamic" }, "recovered");
+    f.store.create({ type: "dynamic" }, "recovered", {});
     expect(f.store.list()).toHaveLength(2);
   });
 
@@ -136,11 +136,11 @@ describe("non-replacing initialized lock claims", () => {
     writeFileSync(join(f.lockPath, "owner-999998-dead-b"), "999998:dead-b");
     if (live) writeFileSync(join(f.lockPath, `owner-${process.pid}-live`), `${process.pid}:live`);
     if (live) {
-      expect(() => f.store.create({ type: "dynamic" }, "must not enter")).toThrow(/lock/i);
+      expect(() => f.store.create({ type: "dynamic" }, "must not enter", {})).toThrow(/lock/i);
       expect(readdirSync(f.lockPath)).toEqual([`owner-${process.pid}-live`]);
       expectUnchanged(f);
     } else {
-      f.store.create({ type: "dynamic" }, "recovered");
+      f.store.create({ type: "dynamic" }, "recovered", {});
       expect(f.store.list()).toHaveLength(2);
       expect(existsSync(f.lockPath)).toBe(false);
     }

--- a/test/lock-publication.test.ts
+++ b/test/lock-publication.test.ts
@@ -29,7 +29,7 @@ vi.mock("node:fs", async (importOriginal) => {
   };
 });
 
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { LoopStore } from "../src/store.js";
 
 const dirs: string[] = [];
@@ -113,6 +113,19 @@ describe("non-replacing initialized lock claims", () => {
     f.store.create({ type: "dynamic" }, "owner", {});
     expect(publications).toBe(1);
     expect(f.store.list().map((entry) => entry.prompt)).toEqual(["original", "owner"]);
+    expect(existsSync(f.lockPath)).toBe(false);
+  });
+
+  it("retries APFS EINVAL when empty scaffolding disappears during publication", () => {
+    const f = fixture();
+    hooks.beforePublish = (lockPath) => {
+      hooks.beforePublish = undefined;
+      rmdirSync(lockPath);
+      throw Object.assign(new Error("scaffolding disappeared during link"), { code: "EINVAL", syscall: "link" });
+    };
+    f.store.create({ type: "dynamic" }, "retried", {});
+    expect(hooks.beforePublish).toBeUndefined();
+    expect(f.store.list()).toHaveLength(2);
     expect(existsSync(f.lockPath)).toBe(false);
   });
 

--- a/test/notification-runtime.test.ts
+++ b/test/notification-runtime.test.ts
@@ -156,6 +156,43 @@ describe("notification runtime session boundary", () => {
     expect.soft(sentMessages[0]?.message.content).toContain("Adopt pending work");
   });
 
+  it("supersession: an older in-flight same-key wake cannot deliver after a newer wake queues while idle", async () => {
+    const { pi, sentMessages } = createMockPi();
+    let entered!: () => void;
+    let release!: () => void;
+    let lookupCount = 0;
+    const lookupEntered = new Promise<void>((resolve) => { entered = resolve; });
+    const delayedLookup = new Promise<number>((resolve) => { release = () => resolve(1); });
+    const runtime = createNotificationRuntime({
+      pi,
+      hasPendingTasks: () => {
+        lookupCount += 1;
+        if (lookupCount !== 1) return Promise.resolve(1);
+        entered();
+        return delayedLookup;
+      },
+      cleanDoneTasks: async () => {},
+      getHasPendingMessages: () => false,
+    });
+    runtime.syncRuntimeState({ agentRunning: false, hasPendingMessages: false });
+
+    const oldWake = runtime.queueOrDeliverNotification({
+      loopId: "1", prompt: "Old instructions", trigger: { type: "cron", schedule: "* * * * *" },
+      timestamp: 1, autoTask: true, recurring: true,
+    });
+    await lookupEntered;
+    const newWake = runtime.queueOrDeliverNotification({
+      loopId: "1", prompt: "New instructions", trigger: { type: "cron", schedule: "* * * * *" },
+      timestamp: 2, autoTask: true, recurring: true,
+    });
+    release();
+    await Promise.all([oldWake, newWake]);
+
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0]?.message.content).toContain("New instructions");
+    expect(sentMessages[0]?.message.content).not.toContain("Old instructions");
+  });
+
   it("RA-04: busy retention preserves a newer same-key wake", async () => {
     const { pi, sentMessages } = createMockPi();
     let entered!: () => void;

--- a/test/orchestration-store.test.ts
+++ b/test/orchestration-store.test.ts
@@ -20,6 +20,19 @@ afterEach(() => {
 });
 
 describe("LoopStore orchestration authority", () => {
+  it.each(["autoTask", "taskBacklog"] as const)("rejects orchestration projection through %s", (flag) => {
+    const { store } = makeStore();
+    expect(() => store.create({ type: "dynamic" }, "Parallel review", {
+      recurring: true,
+      [flag]: true,
+      orchestration: {
+        owner,
+        definition: { goal: "Parallel review", work: [{ prompt: "Inspect" }] },
+      },
+    })).toThrow(/orchestration.*standalone task/i);
+    expect(store.list()).toEqual([]);
+  });
+
   it("persists the finite batch and applies orchestration CAS under the store lock", () => {
     const { path, store } = makeStore();
     const entry = store.create({ type: "dynamic" }, "Parallel review", {

--- a/test/reducer-backed-store.test.ts
+++ b/test/reducer-backed-store.test.ts
@@ -156,6 +156,23 @@ describe("ReducerBackedStore", () => {
       }
     });
 
+    it.each([
+      ["owner", "999999:deadbeef"],
+      [".cleanup-999999-deadbeef", "999998:deadbeef"],
+    ])("recovers the preceding directory lock format %s", (ownerName, contents) => {
+      const path = join(dir, "items.json");
+      const first = new ItemStore(path);
+      first.set("x", 1);
+      const lockPath = `${path}.lock`;
+      mkdirSync(lockPath);
+      writeFileSync(join(lockPath, ownerName), contents);
+
+      new ItemStore(path).set("x", 2);
+
+      expect(new ItemStore(path).get("x")).toEqual({ id: "x", value: 2 });
+      expect(existsSync(lockPath)).toBe(false);
+    });
+
     it("recovers a stale directory owner and publishes a complete replacement", () => {
       const path = join(dir, "items.json");
       const first = new ItemStore(path);

--- a/test/reducer-backed-store.test.ts
+++ b/test/reducer-backed-store.test.ts
@@ -136,21 +136,21 @@ describe("ReducerBackedStore", () => {
       }
     });
 
-    it("RA-01: a live stale-cleanup claim fences replacement lock publication", () => {
+    it("a live uniquely named owner fences replacement lock publication", () => {
       const path = join(dir, "items.json");
       const a = new ItemStore(path);
       a.set("x", 1);
       const before = readFileSync(path, "utf8");
       const lockPath = `${path}.lock`;
       mkdirSync(lockPath);
-      const claimPath = join(lockPath, `.cleanup-${process.pid}-held`);
-      writeFileSync(claimPath, "999999:stale-owner");
+      const claimPath = join(lockPath, `owner-${process.pid}-held`);
+      writeFileSync(claimPath, `${process.pid}:held`);
       let tick = 0;
       const clock = vi.spyOn(Date, "now").mockImplementation(() => (tick += 100));
       try {
         expect(() => new ItemStore(path).set("x", 2)).toThrow(/lock/i);
         expect(readFileSync(path, "utf8")).toBe(before);
-        expect(readFileSync(claimPath, "utf8")).toBe("999999:stale-owner");
+        expect(readFileSync(claimPath, "utf8")).toBe(`${process.pid}:held`);
       } finally {
         clock.mockRestore();
       }
@@ -162,7 +162,7 @@ describe("ReducerBackedStore", () => {
       first.set("x", 1);
       const lockPath = `${path}.lock`;
       mkdirSync(lockPath);
-      writeFileSync(join(lockPath, "owner"), "999999:stale-owner");
+      writeFileSync(join(lockPath, "owner-999999-stale-owner"), "999999:stale-owner");
 
       new ItemStore(path).set("x", 2);
 

--- a/test/reducer-backed-store.test.ts
+++ b/test/reducer-backed-store.test.ts
@@ -1,4 +1,4 @@
-import { closeSync, existsSync, fstatSync, mkdtempSync, openSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, fstatSync, mkdirSync, mkdtempSync, openSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -134,6 +134,40 @@ describe("ReducerBackedStore", () => {
         clock.mockRestore();
         closeSync(fd);
       }
+    });
+
+    it("RA-01: a live stale-cleanup claim fences replacement lock publication", () => {
+      const path = join(dir, "items.json");
+      const a = new ItemStore(path);
+      a.set("x", 1);
+      const before = readFileSync(path, "utf8");
+      const lockPath = `${path}.lock`;
+      mkdirSync(lockPath);
+      const claimPath = join(lockPath, `.cleanup-${process.pid}-held`);
+      writeFileSync(claimPath, "999999:stale-owner");
+      let tick = 0;
+      const clock = vi.spyOn(Date, "now").mockImplementation(() => (tick += 100));
+      try {
+        expect(() => new ItemStore(path).set("x", 2)).toThrow(/lock/i);
+        expect(readFileSync(path, "utf8")).toBe(before);
+        expect(readFileSync(claimPath, "utf8")).toBe("999999:stale-owner");
+      } finally {
+        clock.mockRestore();
+      }
+    });
+
+    it("recovers a stale directory owner and publishes a complete replacement", () => {
+      const path = join(dir, "items.json");
+      const first = new ItemStore(path);
+      first.set("x", 1);
+      const lockPath = `${path}.lock`;
+      mkdirSync(lockPath);
+      writeFileSync(join(lockPath, "owner"), "999999:stale-owner");
+
+      new ItemStore(path).set("x", 2);
+
+      expect(new ItemStore(path).get("x")).toEqual({ id: "x", value: 2 });
+      expect(existsSync(lockPath)).toBe(false);
     });
 
     it("fails closed on malformed owner text with a live PID prefix", () => {

--- a/test/reducer-backed-store.test.ts
+++ b/test/reducer-backed-store.test.ts
@@ -143,14 +143,14 @@ describe("ReducerBackedStore", () => {
       const before = readFileSync(path, "utf8");
       const lockPath = `${path}.lock`;
       mkdirSync(lockPath);
-      const claimPath = join(lockPath, `owner-${process.pid}-held`);
-      writeFileSync(claimPath, `${process.pid}:held`);
+      const claimPath = join(lockPath, `owner-${process.pid}-deadbeef`);
+      writeFileSync(claimPath, `${process.pid}:deadbeef`);
       let tick = 0;
       const clock = vi.spyOn(Date, "now").mockImplementation(() => (tick += 100));
       try {
         expect(() => new ItemStore(path).set("x", 2)).toThrow(/lock/i);
         expect(readFileSync(path, "utf8")).toBe(before);
-        expect(readFileSync(claimPath, "utf8")).toBe(`${process.pid}:held`);
+        expect(readFileSync(claimPath, "utf8")).toBe(`${process.pid}:deadbeef`);
       } finally {
         clock.mockRestore();
       }

--- a/test/stale-lock-replacement.test.ts
+++ b/test/stale-lock-replacement.test.ts
@@ -1,0 +1,108 @@
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const interposition = vi.hoisted(() => ({
+  armed: false,
+  observedOwnerName: "",
+  staleOwnerPath: "",
+  replacementOwnerPath: "",
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    renameSync(source: import("node:fs").PathLike, destination: import("node:fs").PathLike) {
+      const sourcePath = String(source);
+      if (sourcePath.endsWith(".candidate") && actual.statSync(sourcePath).isDirectory()) {
+        interposition.observedOwnerName = actual.readdirSync(sourcePath)[0] ?? "";
+      }
+      return actual.renameSync(source, destination);
+    },
+    readFileSync(path: import("node:fs").PathOrFileDescriptor, options?: unknown) {
+      const pathText = String(path);
+      const value = actual.readFileSync(path as never, options as never);
+      if (interposition.armed && pathText === interposition.staleOwnerPath) {
+        interposition.armed = false;
+        const lockPath = dirname(pathText);
+        actual.rmSync(lockPath, { recursive: true, force: true });
+        actual.mkdirSync(lockPath);
+        const replacementName = interposition.observedOwnerName === "owner"
+          ? "owner"
+          : `owner-${process.pid}-feedface`;
+        interposition.replacementOwnerPath = join(lockPath, replacementName);
+        actual.writeFileSync(interposition.replacementOwnerPath, `${process.pid}:feedface`);
+      }
+      return value;
+    },
+  };
+});
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import type { AnyReducerEffect } from "../src/coordinator.js";
+import { ReducerBackedStore, type ReducerResult } from "../src/reducer-backed-store.js";
+
+interface Item { id: string; value: number }
+interface State { nextId: number; itemsById: Record<string, Item> }
+type Event = { type: "SET"; id: string; value: number };
+interface Data { nextId: number; items: Item[] }
+
+function reduce(state: State, event: Event): ReducerResult<State, AnyReducerEffect> {
+  return {
+    state: { ...state, itemsById: { ...state.itemsById, [event.id]: { id: event.id, value: event.value } } },
+    effects: [],
+  };
+}
+
+class ItemStore extends ReducerBackedStore<Item, State, Event, Data> {
+  constructor(path: string) {
+    super({
+      baseDir: tmpdir(),
+      reduce,
+      toReducerState: (nextId, entries) => ({ nextId, itemsById: Object.fromEntries(entries) }),
+      fromReducerState: (state) => ({ nextId: state.nextId, entries: new Map(Object.entries(state.itemsById)) }),
+      serialize: (nextId, entries) => ({ nextId, items: [...entries.values()] }),
+      deserialize: (data) => ({ nextId: data.nextId, entries: new Map(data.items.map((item) => [item.id, item])) }),
+    }, path);
+  }
+
+  set(id: string, value: number): void {
+    this.withLock(() => { this.applyReducerEvent({ type: "SET", id, value }); });
+  }
+}
+
+const dirs: string[] = [];
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  interposition.armed = false;
+  interposition.observedOwnerName = "";
+  interposition.staleOwnerPath = "";
+  interposition.replacementOwnerPath = "";
+});
+
+describe("stale lock replacement fencing", () => {
+  it("does not remove a live owner published after stale-owner inspection", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-loop-lock-race-"));
+    dirs.push(dir);
+    const path = join(dir, "items.json");
+    new ItemStore(path).set("x", 1);
+    const before = readFileSync(path, "utf8");
+    const lockPath = `${path}.lock`;
+    mkdirSync(lockPath);
+    const staleName = interposition.observedOwnerName === "owner"
+      ? "owner"
+      : "owner-999999-deadbeef";
+    interposition.staleOwnerPath = join(lockPath, staleName);
+    writeFileSync(interposition.staleOwnerPath, "999999:deadbeef");
+    interposition.armed = true;
+    let tick = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => (tick += 100));
+
+    expect(() => new ItemStore(path).set("x", 2)).toThrow(/lock/i);
+    expect(readFileSync(path, "utf8")).toBe(before);
+    expect(existsSync(interposition.replacementOwnerPath)).toBe(true);
+    expect(readFileSync(interposition.replacementOwnerPath, "utf8")).toBe(`${process.pid}:feedface`);
+  });
+});

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -96,6 +96,19 @@ describe("LoopStore (in-memory)", () => {
     expect(store.get(entry.id)?.status).toBe("paused");
   });
 
+  it("treats a missing legacy fire count as zero in expected fire identity", () => {
+    const entry = store.create(cronTrigger, "legacy", { recurring: true });
+    const internal = store as unknown as { entries: Map<string, { fireCount?: number }> };
+    delete internal.entries.get(entry.id)?.fireCount;
+
+    expect(store.fireOrExpire(entry.id, "scheduler", entry.createdAt + 1, {
+      createdAt: entry.createdAt,
+      updatedAt: entry.updatedAt,
+      status: entry.status,
+      fireCount: 0,
+    }).kind).toBe("fired");
+  });
+
   it("gets a loop by ID", () => {
     store.create(cronTrigger, "test", { recurring: true });
     const entry = store.get("1");

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -182,6 +182,42 @@ describe("LoopStore (in-memory)", () => {
     expect(store.list()).toEqual([]);
   });
 
+  it("rejects metadata that would mix workflow and standalone task authority", () => {
+    store.create({ type: "dynamic" }, "Workflow", {
+      recurring: true,
+      workflow: {
+        version: 1,
+        initialState: "work",
+        states: {
+          work: { prompt: "Work.", on: { done: "done" } },
+          done: { prompt: "Done.", terminal: "completed" },
+        },
+      },
+    });
+    const before = store.get("1");
+
+    expect(() => store.updateMetadata("1", { taskBacklog: true })).toThrow(/workflow.*standalone/i);
+    expect(store.get("1")).toEqual(before);
+  });
+
+  it("rejects metadata that would give a workflow a standalone event trigger", () => {
+    store.create({ type: "dynamic" }, "Workflow", {
+      recurring: true,
+      workflow: {
+        version: 1,
+        initialState: "work",
+        states: {
+          work: { prompt: "Work.", on: { done: "done" } },
+          done: { prompt: "Done.", terminal: "completed" },
+        },
+      },
+    });
+
+    expect(() => store.updateMetadata("1", { trigger: { type: "event", source: "tasks:created" } }))
+      .toThrow(/dynamic trigger/i);
+    expect(store.get("1")?.trigger).toEqual({ type: "dynamic" });
+  });
+
   it("rejects a paused terminal transition without trusted admission", () => {
     store.create({ type: "dynamic" }, "Investigate", {
       recurring: true,

--- a/test/task-backlog-runtime.test.ts
+++ b/test/task-backlog-runtime.test.ts
@@ -155,6 +155,17 @@ describe("task-backlog-runtime predicates", () => {
     expect(runtime.isTaskBacklogLoop(makeLoop({ prompt: "x", taskBacklog: false }))).toBe(false);
   });
 
+  it("never classifies workflow or orchestration controllers as backlog workers", () => {
+    const { runtime } = setup();
+    const workflow = makeLoop({ workflow: {} as LoopEntry["workflow"] });
+    const orchestration = makeLoop({ taskBacklog: true, orchestration: {} as LoopEntry["orchestration"] });
+
+    expect(runtime.isAutoTaskWorkerLoop(workflow)).toBe(false);
+    expect(runtime.isTaskBacklogLoop(workflow)).toBe(false);
+    expect(runtime.isAutoTaskWorkerLoop(orchestration)).toBe(false);
+    expect(runtime.isTaskBacklogLoop(orchestration)).toBe(false);
+  });
+
   it("finds the auto-task worker loop among many", () => {
     const { runtime, loops } = setup();
     loops.push(makeLoop({ id: "7", prompt: "unrelated", trigger: { type: "cron", schedule: "*/5 * * * *" } }));
@@ -335,5 +346,24 @@ describe("evaluateTaskBacklog", () => {
     const result = await runtime.evaluateTaskBacklog(undefined, 0);
     expect(result.created).toBe(false);
     expect(result.cleaned).toBe(1);
+  });
+
+  it("does not let native evaluation delete a rebound controller", async () => {
+    let resolvePending: ((pending: number) => void) | undefined;
+    const pending = new Promise<number>((resolve) => { resolvePending = resolve; });
+    let current = true;
+    const { runtime, loops, opts } = setup({
+      hasPendingTasks: vi.fn(() => pending),
+      captureIsCurrent: () => () => current,
+    });
+    loops.push(makeLoop({ id: "1", createdAt: 10 }));
+
+    const evaluation = runtime.evaluateTaskBacklog();
+    current = false;
+    resolvePending?.(0);
+
+    expect(await evaluation).toEqual({ created: false, cleaned: 0 });
+    expect(loops).toHaveLength(1);
+    expect(opts.deleteLoop).not.toHaveBeenCalled();
   });
 });

--- a/test/task-backlog-runtime.test.ts
+++ b/test/task-backlog-runtime.test.ts
@@ -159,11 +159,14 @@ describe("task-backlog-runtime predicates", () => {
     const { runtime } = setup();
     const workflow = makeLoop({ workflow: {} as LoopEntry["workflow"] });
     const orchestration = makeLoop({ taskBacklog: true, orchestration: {} as LoopEntry["orchestration"] });
+    const explicitAutoTask = makeLoop({ autoTask: true });
 
     expect(runtime.isAutoTaskWorkerLoop(workflow)).toBe(false);
     expect(runtime.isTaskBacklogLoop(workflow)).toBe(false);
     expect(runtime.isAutoTaskWorkerLoop(orchestration)).toBe(false);
     expect(runtime.isTaskBacklogLoop(orchestration)).toBe(false);
+    expect(runtime.isAutoTaskWorkerLoop(explicitAutoTask)).toBe(false);
+    expect(runtime.isTaskBacklogLoop(explicitAutoTask)).toBe(false);
   });
 
   it("finds the auto-task worker loop among many", () => {
@@ -305,10 +308,10 @@ describe("cleanupTaskBacklogLoops", () => {
     );
 
     const callOrder = (fn: unknown) => (fn as { mock: { invocationCallOrder: number[] } }).mock.invocationCallOrder[0];
-    expect(callOrder(opts.emitTaskBacklogEmpty)).toBeLessThan(callOrder(opts.removeTrigger));
     expect(callOrder(opts.removeTrigger)).toBeLessThan(callOrder(opts.recordDeletionTombstone));
     expect(callOrder(opts.recordDeletionTombstone)).toBeLessThan(callOrder(opts.deleteLoop));
     expect(callOrder(opts.deleteLoop)).toBeLessThan(callOrder(opts.emitLoopAutodeleted));
+    expect(callOrder(opts.emitLoopAutodeleted)).toBeLessThan(callOrder(opts.emitTaskBacklogEmpty));
   });
 
   it("keeps backlog loops when tasks are still pending", async () => {

--- a/test/task-backlog-runtime.test.ts
+++ b/test/task-backlog-runtime.test.ts
@@ -285,6 +285,23 @@ describe("cleanupTaskBacklogLoops", () => {
     expect(opts.deleteLoop).not.toHaveBeenCalled();
   });
 
+  it("finishes batch retirement before publishing per-controller callbacks", async () => {
+    const loops: LoopEntry[] = [];
+    const { runtime } = setup({
+      getLoops: () => loops,
+      deleteLoop: vi.fn((id: string) => {
+        const index = loops.findIndex((loop) => loop.id === id);
+        if (index >= 0) loops.splice(index, 1);
+      }),
+      emitLoopAutodeleted: vi.fn(() => {
+        expect(loops).toHaveLength(0);
+      }),
+    });
+    loops.push(makeLoop({ id: "1" }), makeLoop({ id: "2", createdAt: 11 }));
+
+    expect(await runtime.cleanupTaskBacklogLoops()).toBe(2);
+  });
+
   it("deletes backlog loops when zero tasks are pending and emits explicit signals", async () => {
     const { runtime, opts, loops } = setup({ hasPendingTasks: vi.fn(async () => 0) });
     loops.push(makeLoop({ id: "1" }));

--- a/test/task-store.test.ts
+++ b/test/task-store.test.ts
@@ -294,6 +294,16 @@ describe("TaskStore (file-backed)", () => {
     expect(store2.get("2")?.subject).toBe("second");
   });
 
+  it("refreshes pending counts after a peer store writes work", () => {
+    const reader = new TaskStore(filePath);
+    const writer = new TaskStore(filePath);
+    expect(reader.pendingCount()).toBe(0);
+
+    writer.create("peer work", "must be observed");
+
+    expect(reader.pendingCount()).toBe(1);
+  });
+
   it("preserves monotonic ids after prune", () => {
     const store1 = new TaskStore(filePath);
     store1.create("done", "desc");

--- a/test/workflow-task-integration.test.ts
+++ b/test/workflow-task-integration.test.ts
@@ -233,6 +233,48 @@ describe("embedded workflow execution integration", () => {
     }
   });
 
+  it("budgets immediate cadence activation for every bounded retry", async () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const h = await setup();
+    try {
+      await h.emitExtension("agent_start", null, h.ctx);
+      await h.toolMap.get("WorkflowCreate")!.execute!("create", {
+        goal: "Retry polling",
+        definition: JSON.stringify({
+          version: 1,
+          initialState: "poll",
+          states: {
+            poll: {
+              prompt: "Poll release.",
+              maxAttempts: 2,
+              loop: { schedule: "* * * * *", maxFires: 1, startImmediately: true },
+              on: { retry: "poll", done: "done" },
+            },
+            done: { prompt: "Report success.", terminal: "completed" },
+          },
+        }),
+      });
+      expect(new LoopStore(h.loopPath).get("1")).toMatchObject({ maxFires: 3, fireCount: 1 });
+      const retried = await h.toolMap.get("WorkflowTransition")!.execute!("retry", {
+        id: "1", outcome: "retry", evidence: "Another bounded poll is required.",
+      });
+      expect(retried.content[0].text).toContain("poll → poll");
+      expect(new LoopStore(h.loopPath).get("1")).toMatchObject({
+        status: "active",
+        fireCount: 2,
+        workflow: { currentState: "poll", attemptsByState: { poll: 2 } },
+      });
+      await h.emitExtension("agent_end", null, h.ctx);
+      await vi.advanceTimersByTimeAsync(90_000);
+      expect(new LoopStore(h.loopPath).get("1")).toMatchObject({
+        fireCount: 3,
+        workflow: { stateFireCounts: { poll: 1 } },
+      });
+    } finally {
+      await h.emitExtension("session_shutdown", null, h.ctx);
+    }
+  });
+
   it("creates task-bearing workflow work before task-provider detection and leaves TaskStore empty", async () => {
     const h = await setup();
     const created = await h.toolMap.get("WorkflowCreate")!.execute!("create", {


### PR DESCRIPTION
## Summary
- make stale lock cleanup identity-conditional and preserve predecessor lock recovery
- add exact pre-fire and post-fire workflow identity fencing
- preserve authorized final delivery snapshots without laundering later state
- make same-key notification ordering monotonic across async admission
- refresh file-backed task evidence before backlog retirement
- enforce controller-domain separation across create, load, metadata, migration, and cleanup
- publish cleanup callbacks only after batch retirement completes

## Validation
- lint: two unchanged optional-chain warnings
- typecheck: passed
- tests: 57 files, 956 tests passed
- build: passed
- package smoke: 116 files passed
- audit: 0 vulnerabilities
- diff check and clean status: passed
- final narrow closure review: clean

## Stack
6 of 6. Base: `fix/controller-lifecycle-authority`.