### PR TITLE
feat(workflow): expose graph convergence warnings

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -109,6 +109,12 @@ Standalone tasks are independently completable backlog items. Related work that 
 
 pi-loop probes external `pi-tasks` through protocol-v2 RPC. When unavailable, the native provider and tools are registered. `autoTask` creates one standalone task per ordinary loop fire. `taskBacklog` adopts existing unfinished tasks and must use a recurring `tasks:created` trigger.
 
+## Graph convergence warnings
+
+Workflow summaries and `/loop` inspection show up to three warning witnesses, with an explicit omitted count. `diagnoseWorkflowGraph(run)` from `@trevonistrevon/pi-loop/api` returns full structured witnesses for closed nonterminal components, nonterminal dead ends, and a current-state terminal route cut off by already-exhausted destinations. It reuses outcome availability rules and does not mutate or reject workflows.
+
+These are warning-only structural and point-in-time checks, not a liveness proof or a prerequisite engine. A reachable exit is not mandatory; an intentional ongoing cycle may still be valid. Diagnostics do not simulate future attempt increments, leases, evidence admission, fire/expiry limits, or future revisions. Revise only when finite completion is intended, preserving the existing revision/transition authority checks.
+
 ## Monitors
 
 `MonitorCreate` spawns a detached process group, buffers bounded output, emits rate-limited progress, and records terminal status in memory. Its `timeout` is a renewable inactivity threshold: stdout/stderr bytes, JSONL progress, and `MonitorUpdate` renew the deadline; total runtime alone never stops an active monitor. `MonitorStop` sends TERM then KILL fallback. `onDone` creates a one-shot completion wake; `workflowId` pauses a workflow state's cadence until terminal monitor outcome.

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -42,6 +42,11 @@ try {
   const packedApi = await import(pathToFileURL(join(temporaryDirectory, "package", "dist", "api.js")).href);
   assert.equal(typeof packedRoot.default, "function", "packed root must load as the Pi extension");
   assert.equal(typeof packedApi.TaskStore, "function", "packed api must load TaskStore");
+  assert.equal(typeof packedApi.diagnoseWorkflowGraph, "function", "packed api must expose graph diagnostics");
+  assert.deepEqual(packedApi.diagnoseWorkflowGraph({
+    definition: { version: 1, initialState: "work", states: { work: { prompt: "Work" } } },
+    currentState: "work", attemptsByState: { work: 1 },
+  }), [{ code: "dead_end", states: ["work"] }]);
 
   console.log(`package smoke passed (${paths.length} files)`);
 } finally {

--- a/src/api.ts
+++ b/src/api.ts
@@ -75,4 +75,5 @@ export type {
   WorkflowTerminalStatus,
   WorkflowTransitionRecord,
 } from "./types.js";
+export { diagnoseWorkflowGraph, type WorkflowGraphWarning } from "./workflow-graph.js";
 export type { WorkflowRevisionInput, WorkflowRevisionResult, WorkflowRevisionSummary } from "./workflow-revision.js";

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -6,6 +6,7 @@ import { renderToolCall, renderToolResult, toolArg } from "../ui/tool-renderer.j
 import { workflowAttemptLabel, workflowDisplayDetails, workflowLeaseLabel, workflowTimingSummaryLine } from "../ui/workflow-presentation.js";
 import { admitWorkflowTransition, type WorkflowAdmissionProvider } from "../workflow-admission.js";
 import { validateWorkflowDefinition } from "../workflow-definition.js";
+import { formatWorkflowGraphWarnings } from "../workflow-graph.js";
 import { getActiveWorkflowStateLoop, getWorkflowOutcomeAvailability, type WorkflowTransitionFailure } from "../workflow-reducer.js";
 import type { WorkflowRevisionSummary } from "../workflow-revision.js";
 import { WorkflowRevisionChangeSchema } from "../workflow-schema.js";
@@ -174,6 +175,8 @@ export function formatWorkflowSummary(entry: LoopEntry, heading: string, failure
   const attempt = workflow.attemptsByState[workflow.currentState] ?? 1;
   const attemptLabel = state?.maxAttempts ? `${attempt}/${state.maxAttempts}` : String(attempt);
   let message = `${heading}\nGoal: ${entry.prompt}\n${workflowTimingSummaryLine(entry, now)}\nDefinition revision: ${workflow.definitionRevision ?? 1}\nCurrent state: ${workflow.currentState}\nTransition sequence: ${workflow.transitionSeq}\nAttempt: ${attemptLabel}`;
+  const graphWarnings = formatWorkflowGraphWarnings(workflow);
+  if (graphWarnings.length) message += `\n${graphWarnings.join("\n")}`;
   if (entry.pause) message += `\nPause cause: ${entry.pause.kind}${entry.pause.reason ? ` — ${entry.pause.reason}` : ""}`;
   if (workflow.lastTransition) message += `\n${formatLastTransitionLines(workflow.lastTransition).join("\n")}`;
   if (state?.prompt) message += `\nInstruction: ${state.prompt}`;

--- a/src/ui/workflow-presentation.ts
+++ b/src/ui/workflow-presentation.ts
@@ -1,6 +1,7 @@
 import { formatLastTransitionLines } from "../loop-format.js";
 import { displayRows, type ToolDisplayDetails, type ToolDisplayTone } from "../tools/tool-result.js";
 import type { LoopEntry } from "../types.js";
+import { formatWorkflowGraphWarnings } from "../workflow-graph.js";
 import { getWorkflowOutcomeAvailability, type WorkflowOutcomeAvailability } from "../workflow-reducer.js";
 
 export type WorkflowActivityStatus = "running" | "paused" | "idle" | "stopped";
@@ -142,6 +143,7 @@ export function workflowDisplayDetails({
     ...workflowTimingLines(entry, now),
     `State: ${workflow.currentState} · revision ${workflow.definitionRevision} · transition ${workflow.transitionSeq}`,
     `Attempt: ${workflowAttemptLabel(entry)}`,
+    ...formatWorkflowGraphWarnings(workflow),
     state?.prompt ? `Instruction: ${state.prompt}` : undefined,
     workflow.activeExecution ? `Work: ${workflow.activeExecution.subject} (${workflow.activeExecution.id})` : undefined,
     `Lease: ${workflowLeaseLabel(entry, now)}`,
@@ -166,6 +168,7 @@ export function formatWorkflowInspection(entry: LoopEntry): string {
     `State: ${workflow.currentState} · attempt ${workflowAttemptLabel(entry)}`,
     `Revision: ${workflow.definitionRevision} · transition: ${workflow.transitionSeq}`,
     `Lease: ${workflowLeaseLabel(entry, now)}`,
+    ...formatWorkflowGraphWarnings(workflow),
     availability.available.length > 0 ? `Outcomes: ${availability.available.join(", ")}` : "Outcomes: none",
     availability.unavailable.length > 0
       ? `Unavailable: ${availability.unavailable.map(unavailableOutcomeLabel).join(", ")}`

--- a/src/workflow-graph.ts
+++ b/src/workflow-graph.ts
@@ -1,0 +1,112 @@
+import type { WorkflowRunState } from "./types.js";
+import { getWorkflowOutcomeAvailability } from "./workflow-reducer.js";
+
+export interface WorkflowGraphWarning {
+  code: "closed_cycle" | "dead_end" | "exhausted_route";
+  states: string[];
+  edges?: Array<{ from: string; outcome: string; to: string }>;
+}
+
+type Graph = Map<string, string[]>;
+
+function reachable(graph: Graph, roots: readonly string[]): Set<string> {
+  const seen = new Set<string>();
+  const pending = [...roots];
+  while (pending.length) {
+    const id = pending.pop()!;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    for (const next of graph.get(id) ?? []) if (!seen.has(next)) pending.push(next);
+  }
+  return seen;
+}
+
+function reversed(graph: Graph): Graph {
+  const result: Graph = new Map([...graph.keys()].map((id) => [id, []]));
+  for (const [from, targets] of graph) for (const to of targets) result.get(to)?.push(from);
+  return result;
+}
+
+function components(graph: Graph): string[][] {
+  const seen = new Set<string>();
+  const finish: string[] = [];
+  // Iterative DFS also handles long legacy plans without using the JS call stack.
+  for (const root of graph.keys()) {
+    const stack: Array<[string, boolean]> = [[root, false]];
+    while (stack.length) {
+      const [id, exiting] = stack.pop()!;
+      if (exiting) { finish.push(id); continue; }
+      if (seen.has(id)) continue;
+      seen.add(id);
+      stack.push([id, true]);
+      for (const next of graph.get(id) ?? []) if (!seen.has(next)) stack.push([next, false]);
+    }
+  }
+  const reverse = reversed(graph);
+  seen.clear();
+  const result: string[][] = [];
+  for (const root of finish.reverse()) {
+    if (seen.has(root)) continue;
+    const group: string[] = [];
+    const stack = [root];
+    while (stack.length) {
+      const id = stack.pop()!;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      group.push(id);
+      for (const next of reverse.get(id) ?? []) if (!seen.has(next)) stack.push(next);
+    }
+    result.push(group.sort());
+  }
+  return result;
+}
+
+/** Warning-only read model over an already validated workflow; not a liveness proof. */
+export function diagnoseWorkflowGraph(run: WorkflowRunState): WorkflowGraphWarning[] {
+  const states = run.definition.states;
+  const ids = Object.keys(states).sort();
+  const graph: Graph = new Map(ids.map((id) => [id, [...new Set(Object.values(states[id]?.on ?? {}))].filter((target) => Object.hasOwn(states, target)).sort()]));
+  const warnings: WorkflowGraphWarning[] = [];
+  for (const group of components(graph)) {
+    if (group.some((id) => states[id]?.terminal)) continue;
+    const members = new Set(group);
+    if (group.some((id) => graph.get(id)?.some((next) => !members.has(next)))) continue;
+    const cycle = group.length > 1 || graph.get(group[0]!)?.includes(group[0]!);
+    warnings.push({ code: cycle ? "closed_cycle" : "dead_end", states: group });
+  }
+
+  const terminals = ids.filter((id) => states[id]?.terminal);
+  const terminalReachable = reachable(reversed(graph), terminals);
+  const live: Graph = new Map();
+  const blocked: NonNullable<WorkflowGraphWarning["edges"]> = [];
+  for (const id of ids) {
+    const availability = getWorkflowOutcomeAvailability({ ...run, currentState: id });
+    live.set(id, availability.available.map((outcome) => states[id]!.on![outcome]!).filter((target) => Object.hasOwn(states, target)));
+    for (const edge of availability.unavailable) blocked.push({ from: id, outcome: edge.outcome, to: edge.targetState });
+  }
+  const currentReachable = reachable(live, [run.currentState]);
+  if (terminalReachable.has(run.currentState) && !terminals.some((id) => currentReachable.has(id))) {
+    const edges = blocked.filter((edge) => currentReachable.has(edge.from) && terminalReachable.has(edge.to))
+      .sort((a, b) => `${a.from}.${a.outcome}` < `${b.from}.${b.outcome}` ? -1 : `${a.from}.${a.outcome}` > `${b.from}.${b.outcome}` ? 1 : 0);
+    warnings.push({ code: "exhausted_route", states: [run.currentState], edges });
+  }
+  return warnings.sort((a, b) => {
+    const left = `${a.code}:${a.states.join(",")}`;
+    const right = `${b.code}:${b.states.join(",")}`;
+    return left < right ? -1 : left > right ? 1 : 0;
+  });
+}
+
+export function formatWorkflowGraphWarnings(run: WorkflowRunState): string[] {
+  const warnings = diagnoseWorkflowGraph(run);
+  const lines = warnings.slice(0, 3).map((warning) => {
+    const names = warning.states.slice(0, 4).join(", ");
+    const suffix = warning.states.length > 4 ? ` (+${warning.states.length - 4} states)` : "";
+    const detail = warning.code === "closed_cycle" ? "cycle has no declared exit"
+      : warning.code === "dead_end" ? "nonterminal state has no outcome"
+        : "no terminal route remains under current attempt limits";
+    return `Graph warning: ${names}${suffix} — ${detail}. Inspect/revise the graph if finite completion is intended.`;
+  });
+  if (warnings.length > 3) lines.push(`Graph warnings: ${warnings.length - 3} more; inspect diagnoseWorkflowGraph via the public API for full witnesses.`);
+  return lines;
+}

--- a/test/property/workflow-graph.property.test.ts
+++ b/test/property/workflow-graph.property.test.ts
@@ -1,0 +1,37 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { LoopStore } from "../../src/store.js";
+import type { WorkflowDefinition } from "../../src/types.js";
+import { diagnoseWorkflowGraph } from "../../src/workflow-graph.js";
+import { propertyOptions } from "./config.js";
+
+describe("workflow graph warning properties", () => {
+  it("matches a bounded reachability oracle for generated closed components", () => {
+    fc.assert(fc.property(fc.array(fc.integer({ min: 0, max: 255 }), { minLength: 2, maxLength: 8 }), (masks) => {
+      const ids = masks.map((_, i) => `s${i}`);
+      const states: WorkflowDefinition["states"] = {};
+      const adjacency = masks.map((mask, from) => ids.map((_, to) => from === 0 ? to !== 0 : (mask & (1 << to)) !== 0));
+      for (const [i, id] of ids.entries()) {
+        states[id] = { prompt: id, maxAttempts: 3, on: Object.fromEntries(ids.filter((_, j) => adjacency[i]![j]).map((target) => [`to-${target}`, target])) };
+      }
+      const run = new LoopStore().create({ type: "dynamic" }, "graph", { recurring: true, workflow: { version: 1, initialState: "s0", states } }).workflow!;
+      const before = structuredClone(run);
+      const paths = adjacency.map((row, i) => row.map((edge, j) => edge || i === j));
+      for (let k = 0; k < ids.length; k++) for (let i = 0; i < ids.length; i++) for (let j = 0; j < ids.length; j++) paths[i]![j] ||= paths[i]![k]! && paths[k]![j]!;
+      const groups: string[][] = [];
+      const covered = new Set<number>();
+      for (let i = 0; i < ids.length; i++) {
+        if (covered.has(i)) continue;
+        const members = ids.map((_, j) => j).filter((j) => paths[i]![j] && paths[j]![i]);
+        for (const j of members) covered.add(j);
+        if (members.every((from) => adjacency[from]!.every((edge, to) => !edge || members.includes(to)))) groups.push(members.map((j) => ids[j]!).sort());
+      }
+      const warnings = diagnoseWorkflowGraph(run);
+      expect(warnings.map((warning) => warning.states.join(",")).sort()).toEqual(groups.map((group) => group.join(",")).sort());
+      expect(run).toEqual(before);
+      const reordered = structuredClone(run);
+      reordered.definition.states = Object.fromEntries(Object.entries(states).reverse());
+      expect(diagnoseWorkflowGraph(reordered)).toEqual(warnings);
+    }), propertyOptions());
+  });
+});

--- a/test/workflow-graph.test.ts
+++ b/test/workflow-graph.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { LoopStore } from "../src/store.js";
+import type { WorkflowDefinition } from "../src/types.js";
+import { diagnoseWorkflowGraph, formatWorkflowGraphWarnings } from "../src/workflow-graph.js";
+
+function run(states: WorkflowDefinition["states"], initialState = "a") {
+  return new LoopStore().create({ type: "dynamic" }, "inspect graph", {
+    recurring: true, workflow: { version: 1, initialState, states },
+  }).workflow!;
+}
+
+describe("workflow convergence diagnostics", () => {
+  it("warns about closed multi-state cycles without rejecting the workflow", () => {
+    const workflow = run({ a: { prompt: "A", on: { next: "b" } }, b: { prompt: "B", on: { back: "a" } } });
+    const before = structuredClone(workflow);
+    expect(diagnoseWorkflowGraph(workflow)).toMatchObject([{ code: "closed_cycle", states: ["a", "b"] }]);
+    expect(workflow).toEqual(before);
+  });
+
+  it("distinguishes nonterminal dead ends from completed or paused terminals", () => {
+    const workflow = run({
+      a: { prompt: "A", on: { stuck: "b", done: "done", blocked: "blocked" } },
+      b: { prompt: "No route" }, done: { prompt: "Done", terminal: "completed" }, blocked: { prompt: "Blocked", terminal: "paused" },
+    });
+    expect(diagnoseWorkflowGraph(workflow)).toMatchObject([{ code: "dead_end", states: ["b"] }]);
+  });
+
+  it("does not warn for a bounded self-loop with an available exit", () => {
+    expect(diagnoseWorkflowGraph(run({ a: { prompt: "A", maxAttempts: 2, on: { retry: "a", done: "done" } }, done: { prompt: "Done", terminal: "completed" } }))).toEqual([]);
+  });
+
+  it("finds an exhausted bridge beyond the current immediate outcomes", () => {
+    const workflow = run({
+      a: { prompt: "A", on: { next: "b" } }, b: { prompt: "B", on: { next: "c" } },
+      c: { prompt: "C", maxAttempts: 1, on: { done: "done" } }, done: { prompt: "Done", terminal: "completed" },
+    });
+    workflow.attemptsByState.c = 1;
+    expect(diagnoseWorkflowGraph(workflow)).toMatchObject([{ code: "exhausted_route", states: ["a"], edges: [{ from: "b", outcome: "next", to: "c" }] }]);
+    workflow.currentState = "c";
+    expect(diagnoseWorkflowGraph(workflow)).toEqual([]);
+  });
+
+  it("does not call an exhausted optional branch a prerequisite trap", () => {
+    const workflow = run({ a: { prompt: "A", on: { via: "b", done: "done" } }, b: { prompt: "B", maxAttempts: 1, on: { done: "done" } }, done: { prompt: "Done", terminal: "completed" } });
+    workflow.attemptsByState.b = 1;
+    expect(diagnoseWorkflowGraph(workflow)).toEqual([]);
+  });
+
+  it("keeps witness order stable across definition insertion order", () => {
+    const workflow = run({ a: { prompt: "A", on: { one: "b", two: "c" } }, b: { prompt: "B" }, c: { prompt: "C" } });
+    const reordered = structuredClone(workflow);
+    reordered.definition.states = Object.fromEntries(Object.entries(reordered.definition.states).reverse());
+    expect(diagnoseWorkflowGraph(reordered)).toEqual(diagnoseWorkflowGraph(workflow));
+  });
+
+  it("bounds inspection warnings and discloses omissions", () => {
+    const workflow = run({ a: { prompt: "A", on: { one: "b", two: "c", three: "d", four: "e" } }, b: { prompt: "B" }, c: { prompt: "C" }, d: { prompt: "D" }, e: { prompt: "E" } });
+    const lines = formatWorkflowGraphWarnings(workflow);
+    expect(lines).toHaveLength(4);
+    expect(lines.at(-1)).toContain("1 more");
+    expect(lines.every((line) => line.length < 800)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Scope
Layer 3/4; base `fix/orchestration-stop-uncertainty`. Keep unmerged with the stack.

- Add pure warning-only graph diagnostics for closed nonterminal components, dead ends, and current terminal routes cut off by exhausted destinations.
- Reuse existing outcome-availability rules; do not mutate or reject workflows.
- Return deterministic structured witnesses through the supported `diagnoseWorkflowGraph` API.
- Bound inspection to three warnings, truncate displayed state lists explicitly, and preserve full API witnesses.
- Add deterministic fixtures, an independent generated reachability oracle, and packed API smoke coverage.

These are structural/point-in-time warnings, not a liveness proof, prerequisite engine, or simulation of future attempts/admission/expiry/revisions.

## Validation
Signed tip `011f7f1`; full local and coverage gates passed (96.52% functions): 1034 tests, 18 property tests, lint/typecheck/build, package smoke (119 files), audit zero, and diff/clean checks. Bounded independent source review completed without blockers. All layer patches remained identical through rebase onto the Windows-repaired #93 base.

An earlier development full-suite run had one unidentified failure; subsequent logged complete runs passed. No flake root cause is claimed. This PR's CI runs separately after opening. No merge requested.
