### PR TITLE
fix(tasks): register native task tools at session_start

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ Monitor output is untrusted and exposed through bounded/rate-limited events. `on
 
 ## Standalone tasks and providers
 
-pi-loop probes protocol-v2 `pi-tasks` and otherwise enables its native provider. Native task RPC registers at extension initialization so early peers cannot race fallback setup.
+pi-loop probes protocol-v2 `pi-tasks` and otherwise enables its native provider. Native task RPC registers at extension initialization so early peers cannot race fallback setup. Native task tools and `/tasks` register at `session_start` (after every extension factory has run) so the first request already carries the final tool set: pi bakes tool schemas and prompt guidelines into the request prefix, and a tool set that changes between requests defeats provider prompt caching. The six-second timer is only a backstop.
 
 Task claims use bearer IDs because they cross extension boundaries. Workflow leases do not expose tokens. Task prerequisites are description conventions, not TaskStore graph fields.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* **tasks:** register the native task tools at `session_start` instead of six seconds after startup. A prompt sent inside that window used to go out with the pre-registration tool set, and the next request carried four more tools plus their prompt guidelines, so the request prefix changed once per session and every provider-side prompt cache missed (a full ~22k-token re-prefill on llama-server). The timer stays as a backstop and an external `pi-tasks` that answered the startup ping still wins.
+
 ## [0.7.13](https://github.com/trvon/pi-loop/compare/pi-loop-v0.7.12...pi-loop-v0.7.13) (2026-09-05)
 
 

--- a/docs/CONTROLLER_ROUTING_EVAL.md
+++ b/docs/CONTROLLER_ROUTING_EVAL.md
@@ -69,4 +69,4 @@ Because no critical or normal routing item failed across two consecutive passes 
 
 The initial full RPC run with `openai-codex/gpt-5.6-sol:minimal` passed all six scenarios at 100% checklist accuracy. The three workflow scenarios each repaired one invalid first attempt in the same user-request turn after incorrectly treating a state-level `loop` field as rework metadata. Their final workflow calls passed and preserved the intended route; the task and loop scenarios required no retries. This is recorded as schema-repair evidence, not hidden or counted as a controller-selection failure.
 
-A 9-second startup window is intentional. Native fallback task tools are registered after the protocol-v2 `pi-tasks` probe; prompting earlier can test tool-registration timing instead of controller judgment.
+A 9-second startup window is intentional. Native fallback task tools now register at `session_start`, before the first request, so the window no longer guards tool registration; it is kept so the protocol-v2 `pi-tasks` probe has settled before controller judgment is measured.

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -220,7 +220,7 @@ When [@tintinweb/pi-tasks](https://github.com/tintinweb/pi-tasks) is available, 
 
 ### Native fallback
 
-If `pi-tasks` does not answer during startup detection, `pi-loop` registers:
+If no `pi-tasks` has answered the startup ping by `session_start` (which runs after every extension has loaded), `pi-loop` registers the native tools right there, before the first request is built, so the tool set — and with it the provider's cached prompt prefix — is the same for every request of the session. A six-second timer remains as a backstop for hosts that never emit `session_start`. The native tools are:
 
 ```text
 TaskCreate subject="Fix deploy polling" description="Replace polling with an event-driven loop"

--- a/src/index.ts
+++ b/src/index.ts
@@ -478,6 +478,15 @@ export default function (pi: ExtensionAPI) {
     },
   });
 
+  // Registered after the session runtime hooks so the session store is bound
+  // when provider readiness adopts persisted backlog loops — the same order the
+  // fallback timer sees, only before the first request instead of six seconds
+  // in. See registerNativeTools in task-provider-runtime.ts for why the tools
+  // must exist before the first request is built.
+  pi.on("session_start", () => {
+    taskProvider?.registerNativeTools("session_start");
+  });
+
   // ── Loop fire handler — queues an in-memory notification, then injects a custom message when delivery is safe ──
 
   pi.events.on("loop:fire", async (event: unknown) => {

--- a/src/runtime/task-provider-runtime.ts
+++ b/src/runtime/task-provider-runtime.ts
@@ -25,6 +25,8 @@ export interface TaskProviderRuntimeOptions {
   fallbackDelayMs?: number;
 }
 
+export type NativeToolsTrigger = "session_start" | "fallback_timer";
+
 export interface TaskProviderRuntime {
   autoCreateTask: ReturnType<typeof createTaskRuntimeBridge>["autoCreateTask"];
   hasPendingTasks: ReturnType<typeof createTaskRuntimeBridge>["hasPendingTasks"];
@@ -32,6 +34,11 @@ export interface TaskProviderRuntime {
   isReady(): boolean;
   summary(): TaskProviderSummary;
   getNativeTaskStore(): TaskStore | undefined;
+  /**
+   * Register the native task tools and `/tasks` now unless an external provider
+   * owns the task channels. Idempotent; returns whether the native tools exist.
+   */
+  registerNativeTools(trigger: NativeToolsTrigger): boolean;
 }
 
 export function createTaskProviderRuntime(options: TaskProviderRuntimeOptions): TaskProviderRuntime {
@@ -118,10 +125,19 @@ export function createTaskProviderRuntime(options: TaskProviderRuntimeOptions): 
     if (!nativeToolsRegistered) bridge.checkTasksVersion();
   });
 
-  const fallbackTimer = setTimeout(() => {
-    if (tasksAvailable || nativeToolsRegistered) return;
+  // Tool registration is part of the request prefix: pi bakes tool schemas and
+  // TaskCreate's prompt guidelines into the system block, so registering after
+  // the first request invalidates the provider's prompt cache once per session
+  // (a full ~22k-token re-prefill on llama-server). The extension entry calls
+  // this from session_start, which runs after every extension factory has
+  // finished — an in-process pi-tasks has answered the ping by then — so the
+  // first request already carries the final tool set. The timer is the backstop
+  // for hosts that never emit session_start.
+  function registerNativeTools(trigger: NativeToolsTrigger): boolean {
+    if (nativeToolsRegistered) return true;
+    if (tasksAvailable) return false;
     const taskStore = getOrCreateNativeTaskStore();
-    if (!taskStore) return;
+    if (!taskStore) return false;
 
     try {
       registerTasksCommand({
@@ -142,15 +158,20 @@ export function createTaskProviderRuntime(options: TaskProviderRuntimeOptions): 
       });
     } catch (error) {
       if (isStaleExtensionContextError(error)) {
-        debug?.("native task fallback skipped: extension context went stale");
-        return;
+        debug?.(`native task fallback skipped on ${trigger}: extension context went stale`);
+        return false;
       }
       throw error;
     }
 
     nativeToolsRegistered = true;
     notifyReady();
-    debug?.("native task tools registered (pi-tasks not detected)");
+    debug?.(`native task tools registered on ${trigger} (pi-tasks not detected)`);
+    return true;
+  }
+
+  const fallbackTimer = setTimeout(() => {
+    registerNativeTools("fallback_timer");
   }, fallbackDelayMs);
 
   pi.on("session_shutdown", () => {
@@ -188,5 +209,6 @@ export function createTaskProviderRuntime(options: TaskProviderRuntimeOptions): 
     isReady: () => tasksAvailable || nativeToolsRegistered,
     summary,
     getNativeTaskStore: () => getOrCreateNativeTaskStore(),
+    registerNativeTools,
   };
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -604,6 +604,38 @@ describe("native task fallback", () => {
     expect(list.content[0].text).toContain("No loops configured");
   });
 
+  it("registers native task tools at session_start so the first request already carries them", async () => {
+    const { pi, toolMap, commandMap, emitExtension } = createMockPi();
+    const registerTool = vi.spyOn(pi, "registerTool");
+    extension(pi as any);
+    await Promise.resolve();
+    expect(toolMap.has("TaskCreate")).toBe(false);
+
+    await emitExtension("session_start", { type: "session_start", reason: "startup" }, createCtx({ sessionId: "prefix-stable-session" }));
+
+    expect(toolMap.has("TaskCreate")).toBe(true);
+    expect(toolMap.has("TaskList")).toBe(true);
+    expect(toolMap.has("TaskUpdate")).toBe(true);
+    expect(toolMap.has("TaskDelete")).toBe(true);
+    expect(commandMap.has("tasks")).toBe(true);
+
+    const registrations = registerTool.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(6100);
+    expect(registerTool.mock.calls.length).toBe(registrations);
+  });
+
+  it("does not register native task tools at session_start when pi-tasks responds", async () => {
+    const { pi, toolMap, commandMap, emitExtension } = createMockPi({ respondToTaskPing: true });
+    extension(pi as any);
+    await Promise.resolve();
+
+    await emitExtension("session_start", { type: "session_start", reason: "startup" }, createCtx({ sessionId: "external-provider-session" }));
+    await vi.advanceTimersByTimeAsync(6100);
+
+    expect(toolMap.has("TaskCreate")).toBe(false);
+    expect(commandMap.has("tasks")).toBe(false);
+  });
+
   it("registers native task tools when pi-tasks is unavailable", async () => {
     const { pi, toolMap, commandMap } = createMockPi();
 

--- a/test/task-provider-runtime.test.ts
+++ b/test/task-provider-runtime.test.ts
@@ -10,7 +10,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-function setup(respondToTaskPing = false) {
+function setup(respondToTaskPing = false, isStaleExtensionContextError: (error: unknown) => boolean = () => false) {
   let sessionId = "session-a";
   let sessionGeneration = 0;
   const mock = createMockPi({ respondToTaskPing });
@@ -25,7 +25,7 @@ function setup(respondToTaskPing = false) {
     onReady,
     getSessionGeneration: () => sessionGeneration,
     updateWidget: vi.fn(),
-    isStaleExtensionContextError: () => false,
+    isStaleExtensionContextError,
   });
   return {
     ...mock,
@@ -124,5 +124,56 @@ describe("task-provider-runtime", () => {
     await vi.advanceTimersByTimeAsync(6_100);
 
     expect(toolMap.has("TaskCreate")).toBe(false);
+  });
+
+  it("registers native tools on demand before the fallback timer fires", async () => {
+    const { pi, toolMap, commandMap, runtime, onReady } = setup();
+    const registerTool = vi.spyOn(pi, "registerTool");
+    expect(toolMap.has("TaskCreate")).toBe(false);
+
+    expect(runtime.registerNativeTools("session_start")).toBe(true);
+
+    expect(toolMap.has("TaskCreate")).toBe(true);
+    expect(toolMap.has("TaskList")).toBe(true);
+    expect(toolMap.has("TaskUpdate")).toBe(true);
+    expect(toolMap.has("TaskDelete")).toBe(true);
+    expect(commandMap.has("tasks")).toBe(true);
+    expect(runtime.isReady()).toBe(true);
+    await Promise.resolve();
+    expect(onReady).toHaveBeenCalledTimes(1);
+
+    const registrations = registerTool.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(6_100);
+    expect(runtime.registerNativeTools("session_start")).toBe(true);
+    expect(registerTool.mock.calls.length).toBe(registrations);
+    expect(onReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not register native tools on demand once an external provider answered", async () => {
+    const { toolMap, commandMap, runtime } = setup(true);
+    await Promise.resolve();
+
+    expect(runtime.registerNativeTools("session_start")).toBe(false);
+
+    expect(toolMap.has("TaskCreate")).toBe(false);
+    expect(commandMap.has("tasks")).toBe(false);
+    await vi.advanceTimersByTimeAsync(6_100);
+    expect(toolMap.has("TaskCreate")).toBe(false);
+    expect(runtime.isReady()).toBe(true);
+  });
+
+  it("swallows a stale extension context during on-demand registration", async () => {
+    const staleError = new Error("This extension ctx is stale after session replacement or reload.");
+    const { pi, toolMap, runtime, onReady } = setup(false, (error) => error === staleError);
+    pi.registerCommand = vi.fn(() => {
+      throw staleError;
+    });
+
+    expect(runtime.registerNativeTools("session_start")).toBe(false);
+
+    expect(toolMap.has("TaskCreate")).toBe(false);
+    expect(runtime.isReady()).toBe(false);
+    await Promise.resolve();
+    expect(onReady).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem

`createTaskProviderRuntime` registers `TaskCreate/TaskList/TaskUpdate/TaskDelete` and `/tasks` on a 6-second `setTimeout` (to yield to a `pi-tasks` whose tool names collide and cannot be unregistered). A prompt sent within those 6 s — every scripted session, and any fast typist — goes out with the pre-registration tool set, and the next request carries four more tools plus TaskCreate's prompt guidelines. pi bakes tool schemas and guidelines into the system block, so the request prefix changes once per session and every provider-side prompt cache misses.

Measured on llama-server (Qwen3.8-27B, hybrid attention, 96k ctx; it logs `selected slot by LCP similarity, f_sim_best = X` and `prompt eval time = … / N tokens` per request). Fresh session, first prompt 4 s after launch, a tool-call turn then a one-line follow-up:

| request | before (timer) | after (session_start) |
|---|---|---|
| 2 (turn 1, after the tool call) | f_sim 0.320, 21 644 tokens re-prefilled, 37.5 s | f_sim 0.965, 773 tokens, 1.8 s |
| 3 (turn 2) | f_sim 0.498, 22 670 tokens, 39.7 s | f_sim 0.978, 703 tokens, 1.8 s |

Request 2 differs from 1 by the tools JSON; request 3 differs from 2 because pi rebuilds the base system prompt (tool snippets/guidelines) only when the next prompt is submitted. Two full re-prefills per session. Registering inside `before_agent_start` is not enough for the same reason: pi captures the base system prompt before that hook chain runs.

## Change

- `task-provider-runtime.ts`: the timer body becomes `registerNativeTools(trigger)` — idempotent, same `tasksAvailable` guard, same stale-context handling, same `notifyReady()` — exposed on the runtime. The timer now just calls it.
- `index.ts`: `pi.on("session_start", () => taskProvider?.registerNativeTools("session_start"))`, registered after `registerSessionRuntimeHooks` so the session store is bound when provider readiness adopts persisted backlog loops — the same order the timer path saw, only before the first request.
- `session_start` runs after every extension factory has finished, so an in-process `pi-tasks` has already answered the startup ping (its `handleRpc` reply is a microtask away). A provider that answered still wins; one that appears after native tools registered is ignored (existing behavior, still tested).
- Tests: runtime-level (on-demand registration before the timer, idempotent with the timer, external provider wins, stale ctx swallowed) and extension-level (`session_start` registers before the timer; no registration when `pi-tasks` responds). Full suite passes (1047). `biome check` and `tsc --noEmit` clean.
- Docs: CHANGELOG (Unreleased — drop it if release-please should own the file), USAGE_GUIDE "Native fallback", CONTROLLER_ROUTING_EVAL startup-window note, AGENTS.md provider section.

Side note: `@tintinweb/pi-tasks` 0.9.0 on npm has no `tasks:rpc` server, so on current installs the ping is never answered and the native tools were always registered — just 6 s late.
